### PR TITLE
fix Aqua's reported piracies and method ambiguities

### DIFF
--- a/src/QSymbolicsBase/basic_superops.jl
+++ b/src/QSymbolicsBase/basic_superops.jl
@@ -29,6 +29,8 @@ kraus(xs::Symbolic{AbstractOperator}...) = KrausRepr(collect(xs))
 basis(x::KrausRepr) = basis(first(x.krausops))
 Base.:(*)(sop::KrausRepr, op::Symbolic{AbstractOperator}) = (+)((i*op*dagger(i) for i in sop.krausops)...)
 Base.:(*)(sop::KrausRepr, k::Symbolic{AbstractKet}) = (+)((i*SProjector(k)*dagger(i) for i in sop.krausops)...)
+Base.:(*)(sop::KrausRepr, k::SZeroOperator) = SZeroOperator()
+Base.:(*)(sop::KrausRepr, k::SZeroKet) = SZeroOperator()
 Base.show(io::IO, x::KrausRepr) = print(io, "𝒦("*join([symbollabel(i) for i in x.krausops], ",")*")")
 
 ##

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,7 +1,9 @@
 @testitem "Aqua" tags=[:aqua] begin
     using Aqua
+    import QuantumInterface as QI
+     own_types = [QI.AbstractBra, QI.AbstractKet, QI.AbstractSuperOperator, QI.AbstractOperator]
     Aqua.test_all(QuantumSymbolics,
-            ambiguities=(;broken=true),
-            piracies=(;broken=true),
+            ambiguities=(),
+            piracies=(;treat_as_own=own_types),
     )
 end

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,9 +1,42 @@
 @testitem "Aqua" tags=[:aqua] begin
     using Aqua
-    import QuantumInterface as QI
-     own_types = [QI.AbstractBra, QI.AbstractKet, QI.AbstractSuperOperator, QI.AbstractOperator]
-    Aqua.test_all(QuantumSymbolics,
-            ambiguities=(),
-            piracies=(;treat_as_own=own_types),
-    )
+    
+    # Add any new types needed to QObj, or here if QObj if not appropriate.
+    # Add types from elsewhere in the ecosystem here or preferably to QObj
+    own_types = [Base.uniontypes(QObj)...,]
+    own_types_union = Union{SymQObj,}
+
+    Aqua.test_all(QuantumSymbolics, piracies=(;treat_as_own=own_types))
+
+    function normalize_arguments(method)
+        args = Base.unwrap_unionall(method.sig).types[2:end]
+        normalized_args = []
+        # handle few edge cases specific to our analysis
+        for arg in args
+            # mutation and order of if-conditions is intedtional here
+            if (arg isa UnionAll) && (arg.body <: Type) arg = arg.body.parameters[1] end
+            if (arg isa Core.TypeofVararg) arg = arg.T end
+            if (arg isa TypeVar) arg = arg.ub end
+            push!(normalized_args, arg)
+        end
+        return normalized_args
+    end
+
+    # Custom type-piracy detection, to catch uses of QuantumInterface types without a Symbolic
+    filtered_piracies = filter(Aqua.Piracy.hunt(QuantumSymbolics)) do m
+        !any(normalize_arguments(m) .<: own_types_union)
+    end
+
+    aqua_piracies = Aqua.Piracy.hunt(QuantumSymbolics, treat_as_own=own_types)
+    internally_detected_piracies = setdiff(filtered_piracies, aqua_piracies)
+    if !isempty(internally_detected_piracies)
+        printstyled(
+            stderr,
+            "Internally flagged possible type-piracy:\n";
+            color = Base.warn_color()
+        )
+        show(stderr, MIME"text/plain"(), internally_detected_piracies)
+        println(stderr, "\n")
+    end
+    @test isempty(internally_detected_piracies)
 end


### PR DESCRIPTION
Fix all of Aqua's reported piracies and method ambiguities. (#65)

Precisely 37 out of the 39 potential piracies are avoided by informing Aqua that types from QuantumInterface are in fact our own. The last two are fixed by adjusting the `* and +` functions that accept a `Vararg`, it had a problem for the case when `N=0`. This solution avoids both the unbound_type_param and the piracy, and seems to be a reasonable design to not allow zero arguments passed to the function (similar to Base operators themselves)


<details>
<summary>PR checklist</summary>

- [ ] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>
</details>


