### PR TITLE
Latexify AbstractSingleBosonOp instead of AbstractSingleBosonGate

### DIFF
--- a/src/QSymbolicsBase/latexify.jl
+++ b/src/QSymbolicsBase/latexify.jl
@@ -26,7 +26,7 @@ end
 @latexrecipe function f(x::Union{SpecialKet,SKet})
     return Expr(:latexifymerge, "\\left|", symbollabel(x), "\\right\\rangle")
 end
-@latexrecipe function f(x::Union{SOperator,SHermitianOperator,SUnitaryOperator,SHermitianUnitaryOperator,AbstractSingleQubitOp,AbstractTwoQubitOp,AbstractSingleBosonGate})
+@latexrecipe function f(x::Union{SOperator,SHermitianOperator,SUnitaryOperator,SHermitianUnitaryOperator,AbstractSingleQubitOp,AbstractTwoQubitOp,AbstractSingleBosonOp})
     return LaTeXString("\\hat $(symbollabel(x))")
 end
 @latexrecipe function f(x::SZero)


### PR DESCRIPTION
Fixes latexify of expressions containing subtypes of `AbstractSingleBosonOp` such as `NumberOp`, `CreateOp`, `DestroyOp`.

Relatedly it doesn't look like `AbstractSingleBosonGate` is used anywhere, and the comment seems like it may be outdated since it seems like implementing `isunitary` is the way such checks are handled?