### PR TITLE
Remove excessive parenthesis in addition and tensor products

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -78,7 +78,7 @@ Similar scaling procedures can be performed on bras and operators. Addition betw
 julia> @op A₁; @op A₂;
 
 julia> A₁+A₂
-(A₁+A₂)
+A₁+A₂
 
 julia> @bra b;
 
@@ -120,7 +120,7 @@ julia> 3*A*B*k
 3AB|k⟩
 
 julia> A⊗(k*b + B)
-(A⊗(B+|k⟩⟨b|))
+A⊗(B+|k⟩⟨b|)
 
 julia> A-A
 𝟎
@@ -215,10 +215,10 @@ julia> using Symbolics
 julia> @op A; @ket k;
 
 julia> ex = 2*A + projector(k)
-(2A+𝐏[|k⟩])
+2A+𝐏[|k⟩]
 
 julia> substitute(ex, Dict([A => X, k => X1]))
-(2X+𝐏[|X₁⟩])
+2X+𝐏[|X₁⟩]
 ```
 
 ## Simplifying Expressions
@@ -259,18 +259,18 @@ Symbolic expressions containing quantum objects can be expanded with the [`qexpa
 julia> @op A; @op B; @op C;
 
 julia> qexpand(A⊗(B+C))
-((A⊗B)+(A⊗C))
+(A⊗B)+(A⊗C)
 
 julia> qexpand((B+C)*A)
-(BA+CA)
+BA+CA
 
 julia> @ket k₁; @ket k₂; @ket k₃;
 
 julia> qexpand(k₁⊗(k₂+k₃))
-(|k₁⟩|k₂⟩+|k₁⟩|k₃⟩)
+|k₁⟩|k₂⟩+|k₁⟩|k₃⟩
 
 julia> qexpand((A*B)*(k₁+k₂))
-(AB|k₁⟩+AB|k₂⟩)
+AB|k₁⟩+AB|k₂⟩
 ```
 
 ## Numerical Translation of Symbolic Objects

--- a/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
@@ -32,7 +32,10 @@ end
 Base.:(*)(op::SZeroOperator, k::Symbolic{AbstractKet}) = SZeroKet()
 Base.:(*)(op::Symbolic{AbstractOperator}, k::SZeroKet) = SZeroKet()
 Base.:(*)(op::SZeroOperator, k::SZeroKet) = SZeroKet()
-Base.show(io::IO, x::SApplyKet) = begin print(io, x.op); print(io, x.ket) end
+function Base.show(io::IO, x::SApplyKet) 
+    str_func = x -> x isa SAdd || x isa STensor ? "("*string(x)*")" : string(x)
+    print(io, join(map(str_func, arguments(x)),""))
+end
 basis(x::SApplyKet) = basis(x.ket)
 
 """Symbolic application of an operator on a bra (from the right).
@@ -65,7 +68,10 @@ end
 Base.:(*)(b::SZeroBra, op::Symbolic{AbstractOperator}) = SZeroBra()
 Base.:(*)(b::Symbolic{AbstractBra}, op::SZeroOperator) = SZeroBra()
 Base.:(*)(b::SZeroBra, op::SZeroOperator) = SZeroBra()
-Base.show(io::IO, x::SApplyBra) = begin print(io, x.bra); print(io, x.op) end
+function Base.show(io::IO, x::SApplyBra) 
+    str_func = x -> x isa SAdd || x isa STensor ? "("*string(x)*")" : string(x)
+    print(io, join(map(str_func, arguments(x)),""))
+end
 basis(x::SApplyBra) = basis(x.bra)
 
 """Symbolic inner product of a bra and a ket.

--- a/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
@@ -33,7 +33,7 @@ Base.:(*)(op::SZeroOperator, k::Symbolic{AbstractKet}) = SZeroKet()
 Base.:(*)(op::Symbolic{AbstractOperator}, k::SZeroKet) = SZeroKet()
 Base.:(*)(op::SZeroOperator, k::SZeroKet) = SZeroKet()
 function Base.show(io::IO, x::SApplyKet) 
-    str_func = x -> x isa SAdd || x isa STensor ? "("*string(x)*")" : string(x)
+    str_func = x -> x isa SAdd || x isa STensorOperator ? "("*string(x)*")" : string(x)
     print(io, join(map(str_func, arguments(x)),""))
 end
 basis(x::SApplyKet) = basis(x.ket)

--- a/src/QSymbolicsBase/basic_superops.jl
+++ b/src/QSymbolicsBase/basic_superops.jl
@@ -13,7 +13,7 @@ julia> K = kraus(A₁, A₂, A₃)
 julia> @op ρ;
 
 julia> K*ρ
-(A₁ρA₁†+A₂ρA₂†+A₃ρA₃†)
+A₁ρA₁†+A₂ρA₂†+A₃ρA₃†
 ```
 """
 @withmetadata struct KrausRepr <: Symbolic{AbstractSuperOperator}

--- a/src/QSymbolicsBase/linalg.jl
+++ b/src/QSymbolicsBase/linalg.jl
@@ -164,7 +164,7 @@ julia> transpose(A)
 Aᵀ
 
 julia> transpose(A+B)
-(Aᵀ+Bᵀ)
+Aᵀ+Bᵀ
 
 julia> transpose(k)
 |k⟩ᵀ
@@ -331,7 +331,7 @@ julia> ptrace(A⊗B, 1)
 julia> @ket k; @bra b;
 
 julia> factorizable = A ⊗ (k*b)
-(A⊗|k⟩⟨b|)
+A⊗|k⟩⟨b|
 
 julia> ptrace(factorizable, 1)
 (tr(A))|k⟩⟨b|
@@ -340,13 +340,13 @@ julia> ptrace(factorizable, 2)
 (⟨b||k⟩)A
 
 julia> mixed_state = (A⊗(k*b)) + ((k*b)⊗B)
-((A⊗|k⟩⟨b|)+(|k⟩⟨b|⊗B))
+(A⊗|k⟩⟨b|)+(|k⟩⟨b|⊗B)
 
 julia> ptrace(mixed_state, 1)
-((0 + ⟨b||k⟩)B+(tr(A))|k⟩⟨b|)
+(0 + ⟨b||k⟩)B+(tr(A))|k⟩⟨b|
 
 julia> ptrace(mixed_state, 2)
-((0 + ⟨b||k⟩)A+(tr(B))|k⟩⟨b|)
+(0 + ⟨b||k⟩)A+(tr(B))|k⟩⟨b|
 ```
 """
 @withmetadata struct SPartialTrace <: Symbolic{AbstractOperator}
@@ -505,7 +505,7 @@ julia> vec(A)
 |A⟩⟩
 
 julia> vec(A+B)
-(|A⟩⟩+|B⟩⟩)
+|A⟩⟩+|B⟩⟩
 ```
 """
 @withmetadata struct SVec <: Symbolic{AbstractKet}

--- a/src/QSymbolicsBase/rules.jl
+++ b/src/QSymbolicsBase/rules.jl
@@ -183,15 +183,15 @@ Manually expand a symbolic expression of quantum objects.
 julia> @op A; @op B; @op C;
 
 julia> qexpand(commutator(A, B))
-(-1BA+AB)
+-1BA+AB
 
 julia> qexpand(A⊗(B+C))
-((A⊗B)+(A⊗C))
+(A⊗B)+(A⊗C)
 
 julia> @ket k₁; @ket k₂;
 
 julia> qexpand(A*(k₁+k₂))
-(A|k₁⟩+A|k₂⟩)
+A|k₁⟩+A|k₂⟩
 ```
 """
 function qexpand(s)


### PR DESCRIPTION
```
@op A; @op B; @op C SpinBasis(1//2) ⊗ SpinBasis(1//2);
```
Before:
```
julia> A + B
(A+B)

julia> C + (A ⊗ B)
((A⊗B)+C)
```
After:
```
julia> A + B
A+B

julia> C + (A ⊗ B)
(A⊗B)+C
```
Same goes for bras, kets, and superoperators.