### PR TITLE
added function Base.zero(x::Symbolic{T})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # News
 
-## v0.4.7 - 2025-02-25
+## v0.4.9 - 2025-04-23
+
+- `Base.zero` implemented for quantum symbolic objects.
+
+## v0.4.8 - 2025-02-25
 
 - Proper expression of outer products in QuantumOptics.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumSymbolics"
 uuid = "efa7fd63-0460-4890-beb7-be1bbdfbaeae"
 authors = ["QuantumSymbolics.jl contributors"]
-version = "0.4.8"
+version = "0.4.9"
 
 [deps]
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"

--- a/docs/src/express.md
+++ b/docs/src/express.md
@@ -6,7 +6,7 @@ DocTestSetup = quote
 end
 ```
 
-A principle feature of `QuantumSymbolics` is to numerically represent symbolic quantum expressions in various formalisms using [`express`](@ref). In particular, one can translate symbolic logic to back-end toolboxes such as [`QuantumOptics.jl`](https://github.com/qojulia/QuantumOptics.jl) or [`QuantumClifford.jl`](https://github.com/QuantumSavory/QuantumClifford.jl) for simulating quantum systems with great flexibiity.
+A principle feature of `QuantumSymbolics` is to numerically represent symbolic quantum expressions in various formalisms using [`express`](@ref). In particular, one can translate symbolic logic to back-end toolboxes such as [`QuantumOptics.jl`](https://github.com/qojulia/QuantumOptics.jl) or [`QuantumClifford.jl`](https://github.com/QuantumSavory/QuantumClifford.jl) for simulating quantum systems with great flexibility.
 
 As a straightforward example, consider the spin-up state $|\uparrow\rangle = |0\rangle$, the eigenstate of the Pauli operator $Z$, which can be expressed in `QuantumSymbolics` as follows:
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -284,7 +284,9 @@ julia> using QuantumOptics
 
 julia> express(exp(X))
 Operator(dim=2x2)
-  basis: Spin(1/2)sparse([1, 2, 1, 2], [1, 1, 2, 2], ComplexF64[1.5430806327160496 + 0.0im, 1.1752011684303352 + 0.0im, 1.1752011684303352 + 0.0im, 1.5430806327160496 + 0.0im], 2, 2)
+  basis: Spin(1/2)
+ 1.5430806327160496 + 0.0im  1.1752011684303352 + 0.0im
+ 1.1752011684303352 + 0.0im  1.5430806327160496 + 0.0im
 ```
 
 To convert to the Clifford representation, an instance of `CliffordRepr` must be passed to [`express`](@ref). For instance, we can represent the projection of the basis state [`X1`](@ref) of the Pauli operator [`X`](@ref) as follows:

--- a/src/QSymbolicsBase/basic_ops_homogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_homogeneous.jl
@@ -41,7 +41,8 @@ function Base.:(*)(c::U, x::Symbolic{T}) where {U<:Union{Number, Symbolic{<:Numb
     end
 end
 
-function Base.zero(x::Symbolic{T}) where T
+
+function Base.zero(x::Symbolic{T}) where T<:QObj
     return SZero{T}()
 end
 

--- a/src/QSymbolicsBase/basic_ops_homogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_homogeneous.jl
@@ -41,11 +41,6 @@ function Base.:(*)(c::U, x::Symbolic{T}) where {U<:Union{Number, Symbolic{<:Numb
     end
 end
 
-
-function Base.zero(x::Symbolic{T}) where T<:QObj
-    return SZero{T}()
-end
-
 Base.:(*)(x::Symbolic{T}, c::Number) where {T<:QObj} = c*x
 Base.:(*)(x::Symbolic{T}, y::Symbolic{S}) where {T<:QObj,S<:QObj} = throw(ArgumentError("multiplication between $(typeof(x)) and $(typeof(y)) is not defined; maybe you are looking for a tensor product `tensor`"))
 Base.:(/)(x::Symbolic{T}, c::Number) where {T<:QObj} = iszero(c) ? throw(DomainError(c,"cannot divide QSymbolics expressions by zero")) : (1/c)*x

--- a/src/QSymbolicsBase/basic_ops_homogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_homogeneous.jl
@@ -40,6 +40,11 @@ function Base.:(*)(c::U, x::Symbolic{T}) where {U<:Union{Number, Symbolic{<:Numb
         SScaled{T}(c, x)
     end
 end
+
+function Base.zero(x::Symbolic{T}) where T
+    return SZero{T}()
+end
+
 Base.:(*)(x::Symbolic{T}, c::Number) where {T<:QObj} = c*x
 Base.:(*)(x::Symbolic{T}, y::Symbolic{S}) where {T<:QObj,S<:QObj} = throw(ArgumentError("multiplication between $(typeof(x)) and $(typeof(y)) is not defined; maybe you are looking for a tensor product `tensor`"))
 Base.:(/)(x::Symbolic{T}, c::Number) where {T<:QObj} = iszero(c) ? throw(DomainError(c,"cannot divide QSymbolics expressions by zero")) : (1/c)*x

--- a/src/QSymbolicsBase/express.jl
+++ b/src/QSymbolicsBase/express.jl
@@ -3,7 +3,7 @@
 #
 # The main function is `express`, which takes a quantum object and a representation and returns an expression of the object in that representation.
 ##
-
+ 
 export express, express_nolookup, consistent_representation
 
 import SymbolicUtils: Symbolic
@@ -28,7 +28,9 @@ julia> express(X1, CliffordRepr())
 
 julia> express(QuantumSymbolics.X)
 Operator(dim=2x2)
-  basis: Spin(1/2)sparse([2, 1], [1, 2], ComplexF64[1.0 + 0.0im, 1.0 + 0.0im], 2, 2)
+  basis: Spin(1/2)
+      ⋅       1.0 + 0.0im
+ 1.0 + 0.0im       ⋅
 
 julia> express(QuantumSymbolics.X, CliffordRepr(), UseAsOperation())
 sX

--- a/src/QSymbolicsBase/literal_objects.jl
+++ b/src/QSymbolicsBase/literal_objects.jl
@@ -143,6 +143,10 @@ Base.show(io::IO, x::SymQObj) = print(io, symbollabel(x)) # fallback that probab
 
 struct SZero{T<:QObj} <: Symbolic{T} end
 
+function Base.zero(x::Symbolic{T}) where T<:QObj
+    return SZero{T}()
+end
+
 """Symbolic zero bra"""
 const SZeroBra = SZero{AbstractBra}
 

--- a/src/QSymbolicsBase/predefined.jl
+++ b/src/QSymbolicsBase/predefined.jl
@@ -160,16 +160,20 @@ julia> MixedState(X1⊗X2)
 
 julia> express(MixedState(X1⊗X2))
 Operator(dim=4x4)
-  basis: [Spin(1/2) ⊗ Spin(1/2)]sparse([1, 2, 3, 4], [1, 2, 3, 4], ComplexF64[0.25 + 0.0im, 0.25 + 0.0im, 0.25 + 0.0im, 0.25 + 0.0im], 4, 4)
+  basis: [Spin(1/2) ⊗ Spin(1/2)]
+ 0.25 + 0.0im        ⋅             ⋅             ⋅     
+       ⋅       0.25 + 0.0im        ⋅             ⋅
+       ⋅             ⋅       0.25 + 0.0im        ⋅
+       ⋅             ⋅             ⋅       0.25 + 0.0im
 
 julia> express(MixedState(X1⊗X2), CliffordRepr())
 𝒟ℯ𝓈𝓉𝒶𝒷
-
+ 
 𝒳ₗ━━
 + X_
 + _X
 𝒮𝓉𝒶𝒷
-
+ 
 𝒵ₗ━━
 + Z_
 + _Z

--- a/test/test_misc_linalg.jl
+++ b/test/test_misc_linalg.jl
@@ -2,6 +2,12 @@
     @op A; @op B;
     O = SZeroOperator()
 
+    @bra p
+    @bra q
+        
+    @ket m
+    @ket n
+    
     @testset "Complex Conjugate" begin
         @test isequal(conj(O), O)
         @test isequal(conj(conj(A)), A)
@@ -25,4 +31,17 @@
     @testset "Exponential" begin
         @test isequal(exp(A), SExpOperator(A))
     end
+
+    @testset "Vector of Operators" begin
+        @test isequal([1 1;-im im]*[A;B], [A + B;im*B-im*A])  
+    end
+
+    @testset "Vector of Kets" begin
+        @test isequal([1 1;-im im] *[p;q], [p + q;im*q-im*p])
+    end
+
+    @testset "Vector of Bras" begin
+        @test isequal([1 1;-im im] *[m;n], [m + n;im*n-im*m])
+    end
+
 end

--- a/test/test_zero_obj.jl
+++ b/test/test_zero_obj.jl
@@ -17,6 +17,7 @@
         @test isequal(anticommutator(A, Oop), Oop) && isequal(anticommutator(Oop, A), Oop) && isequal(anticommutator(Oop, Oop), Oop)
         @test isequal(projector(Ok), Oop)
         @test isequal(dagger(Oop), Oop)
+        @test isequal(zero(A), Oop)
     end
 
     @testset "zero bra and ket tests" begin


### PR DESCRIPTION
Addresses [issue 108](https://github.com/QuantumSavory/QuantumSymbolics.jl/issues/108) by extending Base.zero()

I added tests for the kinds of matrix/vector I was immediately interested in.

I was not able to run the full suite of tests locally due to an error regarding number of threads, but I checked that the isequal() statements evaluated as true in my environment.

>      Testing Running tests...
>      ERROR: julia: -t,--threads=<n>[,auto|<m>]; n must be an integer >= 1
>      ERROR: Package QuantumSymbolics errored during testing