### PR TITLE
Fix `Base.show` methods and add corresponding test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # News
 
+## v0.4.10 - 2025-05-11
+
+- Polish `Base.show` methods for application products and scaled quantum objects.
+- Add test suite for `Base.show` methods of quantum symbolic types.
+
 ## v0.4.9 - 2025-04-23
 
 - `Base.zero` implemented for quantum symbolic objects.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumSymbolics"
 uuid = "efa7fd63-0460-4890-beb7-be1bbdfbaeae"
 authors = ["QuantumSymbolics.jl contributors"]
-version = "0.4.9"
+version = "0.4.10"
 
 [deps]
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"

--- a/src/QSymbolicsBase/basic_ops_homogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_homogeneous.jl
@@ -49,25 +49,49 @@ basis(x::SScaled) = basis(x.obj)
 const SScaledKet = SScaled{AbstractKet}
 function Base.show(io::IO, x::SScaledKet)
     if x.coeff isa Real
-        print(io, "$(x.coeff)$(x.obj)")
+        if x.obj isa SAddKet
+            print(io, "$(x.coeff)($(x.obj))")
+        else
+            print(io, "$(x.coeff)$(x.obj)")
+        end
     else
-        print(io, "($(x.coeff))$(x.obj)")
+        if x.obj isa SAddKet
+            print(io, "($(x.coeff))($(x.obj))")
+        else
+            print(io, "($(x.coeff))$(x.obj)")
+        end
     end
 end
 const SScaledOperator = SScaled{AbstractOperator}
 function Base.show(io::IO, x::SScaledOperator)
     if x.coeff isa Real
-        print(io, "$(x.coeff)$(x.obj)")
+        if x.obj isa SAddOperator
+            print(io, "$(x.coeff)($(x.obj))")
+        else
+            print(io, "$(x.coeff)$(x.obj)")
+        end
     else
-        print(io, "($(x.coeff))$(x.obj)")
+        if x.obj isa SAddOperator
+            print(io, "($(x.coeff))($(x.obj))")
+        else
+            print(io, "($(x.coeff))$(x.obj)")
+        end
     end
 end
 const SScaledBra = SScaled{AbstractBra}
 function Base.show(io::IO, x::SScaledBra)
     if x.coeff isa Real
-        print(io, "$(x.coeff)$(x.obj)")
+        if x.obj isa SAddBra
+            print(io, "$(x.coeff)($(x.obj))")
+        else
+            print(io, "$(x.coeff)$(x.obj)")
+        end
     else
-        print(io, "($(x.coeff))$(x.obj)")
+        if x.obj isa SAddBra
+            print(io, "($(x.coeff))($(x.obj))")
+        else
+            print(io, "($(x.coeff))$(x.obj)")
+        end
     end
 end
 

--- a/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
@@ -69,7 +69,7 @@ Base.:(*)(b::SZeroBra, op::Symbolic{AbstractOperator}) = SZeroBra()
 Base.:(*)(b::Symbolic{AbstractBra}, op::SZeroOperator) = SZeroBra()
 Base.:(*)(b::SZeroBra, op::SZeroOperator) = SZeroBra()
 function Base.show(io::IO, x::SApplyBra) 
-    str_func = x -> x isa SAdd || x isa STensor ? "("*string(x)*")" : string(x)
+    str_func = x -> x isa SAdd || x isa STensorOperator ? "("*string(x)*")" : string(x)
     print(io, join(map(str_func, arguments(x)),""))
 end
 basis(x::SApplyBra) = basis(x.bra)

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -1,0 +1,87 @@
+@testitem "Base show methods" begin
+    @op A; @op B;
+    @superop S;
+    @bra b₁; @bra b₂;
+    @ket k₁; @ket k₂;
+
+    @testset "symbolic literal objects" begin
+        @test repr(k₁) == "|k₁⟩"
+        @test repr(b₁) == "⟨b₁|"
+        @test repr(A) == "A"
+        @test repr(S) == "S"
+        @test repr(zero(k₁)) == repr(zero(b₁)) == repr(zero(A)) == repr(zero(S)) == "𝟎"
+    end
+
+    @testset "symbolic addition" begin
+        @test repr(k₁ + k₂) == "|k₁⟩+|k₂⟩"
+        @test repr(b₁ + b₂) == "⟨b₁|+⟨b₂|"
+        @test repr(A + B) == "A+B"
+    end
+    
+    @testset "symbolic application products" begin
+        @test repr(A * k₁) == "A|k₁⟩"
+        @test repr(b₁ * A) == "⟨b₁|A"
+        @test repr((A + B) * k₁) == "(A+B)|k₁⟩"
+        @test repr(b₁ * (A + B)) == "⟨b₁|(A+B)"
+        @test repr((A + B) * (k₁ + k₂)) == "(A+B)(|k₁⟩+|k₂⟩)"
+        @test repr((b₁ + b₂) * (A + B)) == "(⟨b₁|+⟨b₂|)(A+B)"
+        @test repr((A ⊗ B) * SKet(:k, SpinBasis(1//2)^2)) == "(A⊗B)|k⟩"
+        @test repr(SBra(:b, SpinBasis(1//2)^2) * (A ⊗ B)) == "⟨b|(A⊗B)"
+        @test repr((A ⊗ B) * (k₁ ⊗ k₂)) == "(A⊗B)|k₁⟩|k₂⟩"
+        @test repr((b₁ ⊗ b₂) * (A ⊗ B)) == "⟨b₁|⟨b₂|(A⊗B)"
+    end
+
+    @testset "symbolic scaling" begin
+        @test repr(2 * k₁) == "2|k₁⟩"
+        @test repr(2 * b₁) == "2⟨b₁|"
+        @test repr(2 * A) == "2A"
+        @test repr(2 * (k₁ + k₂)) == "2(|k₁⟩+|k₂⟩)"
+        @test repr(2 * (b₁ + b₂)) == "2(⟨b₁|+⟨b₂|)"
+        @test repr(2 * (A + B)) == "2(A+B)"
+        @test repr(2 * (k₁ ⊗ k₂)) == "2|k₁⟩|k₂⟩"
+        @test repr(2 * (b₁ ⊗ b₂)) == "2⟨b₁|⟨b₂|"
+        @test repr(2 * (A ⊗ B)) == "2A⊗B"
+        @test repr((1 + im) * k₁) == "(1 + 1im)|k₁⟩"
+        @test repr((1 + im) * b₁) == "(1 + 1im)⟨b₁|"
+        @test repr((1 + im) * A) == "(1 + 1im)A"
+        @test repr((1 + im) * (k₁ + k₂)) == "(1 + 1im)(|k₁⟩+|k₂⟩)"
+        @test repr((1 + im) * (b₁ + b₂)) == "(1 + 1im)(⟨b₁|+⟨b₂|)"
+        @test repr((1 + im) * (A + B)) == "(1 + 1im)(A+B)"
+        @test repr((1 + im) * (k₁ ⊗ k₂)) == "(1 + 1im)|k₁⟩|k₂⟩"
+        @test repr((1 + im) * (b₁ ⊗ b₂)) == "(1 + 1im)⟨b₁|⟨b₂|"
+        @test repr((1 + im) * (A ⊗ B)) == "(1 + 1im)A⊗B"
+    end
+    
+    @testset "symbolic inner and outer products" begin
+        @test repr(b₁ * k₁) == "⟨b₁||k₁⟩"
+        @test repr(k₁ * b₁) == "|k₁⟩⟨b₁|"
+    end
+
+    @testset "symbolic superoperators" begin
+        @test repr(S * A) == "S[A]"
+    end
+
+    @testset "symbolic commutator and anticommutator" begin
+        @test repr(commutator(A, B)) == "[A,B]"
+        @test repr(anticommutator(A, B)) == "{A,B}"
+    end
+
+    @testset "symbolic linear algebra operations" begin
+        @test repr(conj(k₁)) == "|k₁⟩ˣ"
+        @test repr(conj(b₁)) == "⟨b₁|ˣ"
+        @test repr(conj(A)) == "Aˣ"
+        @test repr(projector(k₁)) == "𝐏[|k₁⟩]"
+        @test repr(transpose(k₁)) == "|k₁⟩ᵀ"
+        @test repr(transpose(b₁)) == "⟨b₁|ᵀ"
+        @test repr(transpose(A)) == "Aᵀ"
+        @test repr(dagger(k₁)) == "|k₁⟩†"
+        @test repr(dagger(b₁)) == "⟨b₁|†"
+        @test repr(dagger(A)) == "A†"
+        @test repr(tr(A)) == "tr(A)"
+        @test repr(ptrace(A ⊗ B, 1)) == "(tr(A))B"
+        @test repr(ptrace(SOperator(:A, SpinBasis(1//2)^2), 1)) == "tr1(A)"
+        @test repr(inv(A)) == "A⁻¹"
+        @test repr(exp(A)) == "exp(A)"
+        @test repr(vec(A)) == "|A⟩⟩"
+    end
+end


### PR DESCRIPTION
Fixes #110 and also the following display for the application of tensor products of operators onto tensor products of bras:
```
julia> (b₁ ⊗ b₂) * (A ⊗ B) # before
(⟨b₁|⟨b₂|)(A⊗B)

julia> (b₁ ⊗ b₂) * (A ⊗ B) # after
⟨b₁|⟨b₂|(A⊗B)
```
Adds a test suite to systematically test/track `Base.show` methods, in addition to the doc tests currently in place.