### PR TITLE
Move raw QuantumClifford register symbolic apply dispatch into the Clifford extension

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,17 +19,13 @@ steps:
       - echo "TERM=$${TERM} | PYTHON=$${PYTHON} | PYCALL_DEBUG_BUILD=$${PYCALL_DEBUG_BUILD}"
     env:
       JET_TEST: "{{matrix.JET_TEST}}"
-    agents:
-      queue: "{{matrix.QUEUE}}"
     matrix:
       setup:
         LABEL: ["base tests"]
-        QUEUE: ["default"]
         JET_TEST: ["false"]
       adjustments:
         - with:
             LABEL: "JET"
-            QUEUE: default
             JET_TEST: true
   
   - label: "Downstream Tests - {{matrix.PACKAGE}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.4.16 - 2026-04-01
+
+- Add `QuantumClifford.Register` symbolic `apply!` methods to the `QuantumClifford` extension.
+
 ## v0.4.15 - 2026-03-19
 
 - `QuantumOpticsRepr` support for BosonicThermalState, PhaseShiftOp, BeamSplitterOp, TwoSqueezedState, TwoSqueezeOp

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumSymbolics"
 uuid = "efa7fd63-0460-4890-beb7-be1bbdfbaeae"
 authors = ["QuantumSymbolics.jl contributors"]
-version = "0.4.15"
+version = "0.4.16"
 
 [workspace]
 projects = ["benchmark", "docs"]

--- a/ext/QuantumCliffordExt/QuantumCliffordExt.jl
+++ b/ext/QuantumCliffordExt/QuantumCliffordExt.jl
@@ -1,7 +1,7 @@
 module QuantumCliffordExt
 
 using QuantumInterface
-using QuantumInterface: AbstractKet, AbstractOperator, CompositeBasis
+using QuantumInterface: AbstractKet, AbstractOperator, AbstractSuperOperator, CompositeBasis
 using QuantumSymbolics
 using QuantumSymbolics: HGate, XGate, YGate, ZGate, CPHASEGate, CNOTGate,
     XBasisState, YBasisState, ZBasisState, MixedState, IdentityOp,
@@ -97,6 +97,22 @@ function QuantumClifford.apply!(
         apply_popindex!(state, indices, g)
     end
     state
+end
+
+function QuantumClifford.apply!(
+    r::QuantumClifford.Register,
+    indices::Base.AbstractVecOrTuple{Int},
+    operation::Symbolic{AbstractOperator},
+)
+    QuantumClifford.apply!(r, indices, express(operation, CliffordRepr(), UseAsOperation()))
+end
+
+function QuantumClifford.apply!(
+    r::QuantumClifford.Register,
+    indices::Base.AbstractVecOrTuple{Int},
+    operation::Symbolic{AbstractSuperOperator},
+)
+    QuantumClifford.apply!(r, indices, express(operation, CliffordRepr(), UseAsOperation()))
 end
 
 apply_popindex!(

--- a/test/test_express_cliff.jl
+++ b/test/test_express_cliff.jl
@@ -60,4 +60,16 @@
         @test expect(P"ZI", state) ≈ -1
         @test expect(P"IX", state) ≈ -1
     end
+
+    @testset "Clifford register symbolic apply" begin
+        symbolic_reg = QuantumClifford.Register(copy(express(Z1, CR)))
+        explicit_reg = QuantumClifford.Register(copy(express(Z1, CR)))
+
+        apply!(symbolic_reg, (1,), QuantumSymbolics.X)
+        apply!(explicit_reg, (1,), express(QuantumSymbolics.X, CR, UseOp))
+
+        @test symbolic_reg == explicit_reg
+        @test expect(P"Z", symbolic_reg.stab) ≈ -1
+        @test_throws MethodError apply!(symbolic_reg, (1,), QuantumSymbolics.X; time=0.0)
+    end
 end


### PR DESCRIPTION
Summary:
- add QuantumClifford.apply! methods for raw QuantumClifford.Register objects and symbolic Clifford operations in QuantumCliffordExt
- add extension tests covering raw-register symbolic apply! and the absence of the time keyword
- bump the package version to 0.4.16 and record the change in the changelog

Context:
This is the dependency-side follow-up for QuantumSavory.jl PR 370, which removes the raw QuantumClifford.Register shims from QuantumSavory.

Validation:
- julia -tauto --project=. -e "using Pkg; Pkg.test()"
- validated QuantumSavory focused tests against this branch with local Pkg.develop(path=...) for both repos