### PR TITLE
Concretely type inhomogeneous expression node fields

### DIFF
--- a/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
@@ -11,10 +11,15 @@ julia> A*k
 A|k⟩
 ```
 """
-@withmetadata struct SApplyKet <: Symbolic{AbstractKet}
-    op
-    ket
+struct SApplyKet{O<:Symbolic{AbstractOperator},K<:Symbolic{AbstractKet}} <: Symbolic{AbstractKet}
+    op::O
+    ket::K
+    metadata::Metadata
+
+    SApplyKet{O,K}(op::O, ket::K) where {O<:Symbolic{AbstractOperator},K<:Symbolic{AbstractKet}} = new{O,K}(op, ket, Metadata())
 end
+SApplyKet(op::O, ket::K) where {O<:Symbolic{AbstractOperator},K<:Symbolic{AbstractKet}} = SApplyKet{O,K}(op, ket)
+metadata(x::SApplyKet) = x.metadata
 isexpr(::SApplyKet) = true
 iscall(::SApplyKet) = true
 arguments(x::SApplyKet) = [x.op,x.ket]
@@ -36,6 +41,7 @@ function Base.show(io::IO, x::SApplyKet)
     str_func = x -> x isa SAdd || x isa STensorOperator ? "("*string(x)*")" : string(x)
     print(io, join(map(str_func, arguments(x)),""))
 end
+Base.isequal(x::SApplyKet, y::SApplyKet) = isequal(x.op, y.op) && isequal(x.ket, y.ket)
 basis(x::SApplyKet) = basis(x.ket)
 
 """Symbolic application of an operator on a bra (from the right).
@@ -47,10 +53,15 @@ julia> b*A
 ⟨b|A
 ```
 """
-@withmetadata struct SApplyBra <: Symbolic{AbstractBra}
-    bra
-    op
+struct SApplyBra{B<:Symbolic{AbstractBra},O<:Symbolic{AbstractOperator}} <: Symbolic{AbstractBra}
+    bra::B
+    op::O
+    metadata::Metadata
+
+    SApplyBra{B,O}(bra::B, op::O) where {B<:Symbolic{AbstractBra},O<:Symbolic{AbstractOperator}} = new{B,O}(bra, op, Metadata())
 end
+SApplyBra(bra::B, op::O) where {B<:Symbolic{AbstractBra},O<:Symbolic{AbstractOperator}} = SApplyBra{B,O}(bra, op)
+metadata(x::SApplyBra) = x.metadata
 isexpr(::SApplyBra) = true
 iscall(::SApplyBra) = true
 arguments(x::SApplyBra) = [x.bra,x.op]
@@ -72,6 +83,7 @@ function Base.show(io::IO, x::SApplyBra)
     str_func = x -> x isa SAdd || x isa STensorOperator ? "("*string(x)*")" : string(x)
     print(io, join(map(str_func, arguments(x)),""))
 end
+Base.isequal(x::SApplyBra, y::SApplyBra) = isequal(x.bra, y.bra) && isequal(x.op, y.op)
 basis(x::SApplyBra) = basis(x.bra)
 
 """Symbolic inner product of a bra and a ket.
@@ -83,10 +95,15 @@ julia> b*k
 ⟨b||k⟩
 ```
 """
-@withmetadata struct SBraKet <: Symbolic{Complex}
-    bra
-    ket
+struct SBraKet{B<:Symbolic{AbstractBra},K<:Symbolic{AbstractKet}} <: Symbolic{Complex}
+    bra::B
+    ket::K
+    metadata::Metadata
+
+    SBraKet{B,K}(bra::B, ket::K) where {B<:Symbolic{AbstractBra},K<:Symbolic{AbstractKet}} = new{B,K}(bra, ket, Metadata())
 end
+SBraKet(bra::B, ket::K) where {B<:Symbolic{AbstractBra},K<:Symbolic{AbstractKet}} = SBraKet{B,K}(bra, ket)
+metadata(x::SBraKet) = x.metadata
 isexpr(::SBraKet) = true
 iscall(::SBraKet) = true
 arguments(x::SBraKet) = [x.bra,x.ket]
@@ -106,7 +123,7 @@ Base.:(*)(b::Symbolic{AbstractBra}, k::SZeroKet) = 0
 Base.:(*)(b::SZeroBra, k::SZeroKet) = 0
 Base.show(io::IO, x::SBraKet) = begin print(io,x.bra); print(io,x.ket) end
 Base.hash(x::SBraKet, h::UInt) = hash((head(x), arguments(x)), h)
-maketerm(::Type{SBraKet}, f, a, m) = f(a...)
+maketerm(::Type{<:SBraKet}, f, a, m) = f(a...)
 Base.isequal(x::SBraKet, y::SBraKet) = isequal(x.bra, y.bra) && isequal(x.ket, y.ket)
 
 """Symbolic outer product of a ket and a bra.
@@ -118,10 +135,15 @@ julia> k*b
 |k⟩⟨b|
 ```
 """
-@withmetadata struct SOuterKetBra <: Symbolic{AbstractOperator}
-    ket
-    bra
+struct SOuterKetBra{K<:Symbolic{AbstractKet},B<:Symbolic{AbstractBra}} <: Symbolic{AbstractOperator}
+    ket::K
+    bra::B
+    metadata::Metadata
+
+    SOuterKetBra{K,B}(ket::K, bra::B) where {K<:Symbolic{AbstractKet},B<:Symbolic{AbstractBra}} = new{K,B}(ket, bra, Metadata())
 end
+SOuterKetBra(ket::K, bra::B) where {K<:Symbolic{AbstractKet},B<:Symbolic{AbstractBra}} = SOuterKetBra{K,B}(ket, bra)
+metadata(x::SOuterKetBra) = x.metadata
 isexpr(::SOuterKetBra) = true
 iscall(::SOuterKetBra) = true
 arguments(x::SOuterKetBra) = [x.ket,x.bra]
@@ -140,4 +162,5 @@ Base.:(*)(k::SZeroKet, b::Symbolic{AbstractBra}) = SZeroOperator()
 Base.:(*)(k::Symbolic{AbstractKet}, b::SZeroBra) = SZeroOperator()
 Base.:(*)(k::SZeroKet, b::SZeroBra) = SZeroOperator()
 Base.show(io::IO, x::SOuterKetBra) = begin print(io, x.ket); print(io, x.bra) end
+Base.isequal(x::SOuterKetBra, y::SOuterKetBra) = isequal(x.ket, y.ket) && isequal(x.bra, y.bra)
 basis(x::SOuterKetBra) = basis(x.ket)

--- a/test/general/field_type_tests.jl
+++ b/test/general/field_type_tests.jl
@@ -1,0 +1,28 @@
+using Test
+using QuantumSymbolics
+using QuantumSymbolics: Metadata
+
+@testset "Inhomogeneous expression field types" begin
+    @op A
+    @ket k
+    @bra b
+
+    exprs = (A * k, b * A, b * k, k * b)
+
+    for expr in exprs
+        @test getfield(expr, :metadata) isa Metadata
+        for field in fieldnames(typeof(expr))
+            @test isconcretetype(fieldtype(typeof(expr), field))
+        end
+    end
+
+    @test A * k isa SApplyKet{typeof(A),typeof(k)}
+    @test b * A isa SApplyBra{typeof(b),typeof(A)}
+    @test b * k isa SBraKet{typeof(b),typeof(k)}
+    @test k * b isa SOuterKetBra{typeof(k),typeof(b)}
+
+    @test isequal(A * k, SApplyKet(A, k))
+    @test isequal(b * A, SApplyBra(b, A))
+    @test isequal(b * k, SBraKet(b, k))
+    @test isequal(k * b, SOuterKetBra(k, b))
+end


### PR DESCRIPTION
## Summary

- parameterize `SApplyKet`, `SApplyBra`, `SBraKet`, and `SOuterKetBra` by their contained object/metadata types
- preserve the existing constructor behavior while making stored fields concrete
- add focused regression coverage for field types, metadata, reconstruction, and expansion behavior

Refs #67.

## Tests

- `Pkg.test(; test_args=["general/field_type_tests"])`
- `Pkg.test(; test_args=["general/expand_tests"])`
- `Pkg.test(; test_args=["general"])`