### PR TITLE
Concretely type fock and scalar expression fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## unreleased
+
+- Concretely type scalar expression wrappers and Fock-space numeric symbolic fields.
+
 ## v0.4.16 - 2026-04-01
 
 - Add `QuantumClifford.Register` symbolic `apply!` methods to the `QuantumClifford` extension.

--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -144,9 +144,9 @@ Base.isequal(::Symbolic{Complex}, ::SymQObj) = false
 const SymScalar = Symbolic{Complex}
 
 """Symbolic scaled scalar expression: `coeff * obj` where obj is a `Symbolic{Complex}`."""
-struct SScaledComplex <: Symbolic{Complex}
-    coeff
-    obj
+struct SScaledComplex{C,O<:SymScalar} <: Symbolic{Complex}
+    coeff::C
+    obj::O
 end
 isexpr(::SScaledComplex) = true
 iscall(::SScaledComplex) = true
@@ -155,14 +155,14 @@ operation(::SScaledComplex) = *
 head(::SScaledComplex) = :*
 children(x::SScaledComplex) = [:*, x.coeff, x.obj]
 metadata(::SScaledComplex) = nothing
-maketerm(::Type{SScaledComplex}, f, a, m) = f(a...)
+maketerm(::Type{<:SScaledComplex}, f, a, m) = f(a...)
 Base.show(io::IO, x::SScaledComplex) = print(io, "($(x.coeff))$(x.obj)")
 Base.hash(x::SScaledComplex, h::UInt) = hash((head(x), x.coeff, x.obj), h)
 Base.isequal(x::SScaledComplex, y::SScaledComplex) = isequal(x.coeff, y.coeff) && isequal(x.obj, y.obj)
 
 """Symbolic sum of scalar expressions."""
-struct SAddComplex <: Symbolic{Complex}
-    terms
+struct SAddComplex{T<:AbstractVector} <: Symbolic{Complex}
+    terms::T
 end
 isexpr(::SAddComplex) = true
 iscall(::SAddComplex) = true
@@ -171,14 +171,14 @@ operation(::SAddComplex) = +
 head(::SAddComplex) = :+
 children(x::SAddComplex) = [:+; x.terms]
 metadata(::SAddComplex) = nothing
-maketerm(::Type{SAddComplex}, f, a, m) = f(a...)
+maketerm(::Type{<:SAddComplex}, f, a, m) = f(a...)
 Base.show(io::IO, x::SAddComplex) = print(io, join(map(string, x.terms), "+"))
 Base.hash(x::SAddComplex, h::UInt) = hash((:+, Set(x.terms)), h)
 Base.isequal(x::SAddComplex, y::SAddComplex) = Set(x.terms) == Set(y.terms)
 
 """Symbolic product of scalar expressions."""
-struct SMulComplex <: Symbolic{Complex}
-    terms
+struct SMulComplex{T<:AbstractVector} <: Symbolic{Complex}
+    terms::T
 end
 isexpr(::SMulComplex) = true
 iscall(::SMulComplex) = true
@@ -187,7 +187,7 @@ operation(::SMulComplex) = *
 head(::SMulComplex) = :*
 children(x::SMulComplex) = [:*; x.terms]
 metadata(::SMulComplex) = nothing
-maketerm(::Type{SMulComplex}, f, a, m) = f(a...)
+maketerm(::Type{<:SMulComplex}, f, a, m) = f(a...)
 Base.show(io::IO, x::SMulComplex) = print(io, join(map(string, x.terms), "*"))
 Base.hash(x::SMulComplex, h::UInt) = hash((:*, x.terms), h)
 Base.isequal(x::SMulComplex, y::SMulComplex) = isequal(x.terms, y.terms)

--- a/src/QSymbolicsBase/predefined_fock.jl
+++ b/src/QSymbolicsBase/predefined_fock.jl
@@ -16,21 +16,24 @@ end
 symbollabel(x::FockState) = "$(x.idx)"
 
 """Coherent state in defined Fock basis."""
-@withmetadata struct CoherentState <: AbstractSingleBosonState
-    alpha::Number # TODO parameterize
+@withmetadata struct CoherentState{T<:Number} <: AbstractSingleBosonState
+    alpha::T
 end
+CoherentState(alpha::T) where {T<:Number} = CoherentState{T}(alpha)
 symbollabel(x::CoherentState) = "$(x.alpha)"
 
 """Squeezed vacuum state in defined Fock basis."""
-@withmetadata struct SqueezedState <: AbstractSingleBosonState
-    z::Number
+@withmetadata struct SqueezedState{T<:Number} <: AbstractSingleBosonState
+    z::T
 end
+SqueezedState(z::T) where {T<:Number} = SqueezedState{T}(z)
 symbollabel(x::SqueezedState) = "0,$(x.z)"
 
 """Two-mode squeezed vacuum state, or EPR state, in defined Fock basis."""
-@withmetadata struct TwoSqueezedState <: AbstractTwoBosonState
-    z::Number
+@withmetadata struct TwoSqueezedState{T<:Number} <: AbstractTwoBosonState
+    z::T
 end
+TwoSqueezedState(z::T) where {T<:Number} = TwoSqueezedState{T}(z)
 symbollabel(x::TwoSqueezedState) = "0,$(x.z)"
 
 """Single-mode vacuum state"""
@@ -112,9 +115,10 @@ julia> qsimplify(phase*c, rewriter=qsimplify_fock)
 |1.2246467991473532e-16 - 1.0im⟩
 ```
 """
-@withmetadata struct PhaseShiftOp <: AbstractSingleBosonGate
-    phase::Number
+@withmetadata struct PhaseShiftOp{T<:Number} <: AbstractSingleBosonGate
+    phase::T
 end
+PhaseShiftOp(phase::T) where {T<:Number} = PhaseShiftOp{T}(phase)
 symbollabel(x::PhaseShiftOp) = "U($(x.phase))"
 
 """Displacement operator in defined Fock basis.
@@ -130,9 +134,10 @@ julia> qsimplify(displace*f, rewriter=qsimplify_fock)
 |im⟩
 ```
 """
-@withmetadata struct DisplaceOp <: AbstractSingleBosonGate
-    alpha::Number
+@withmetadata struct DisplaceOp{T<:Number} <: AbstractSingleBosonGate
+    alpha::T
 end
+DisplaceOp(alpha::T) where {T<:Number} = DisplaceOp{T}(alpha)
 symbollabel(x::DisplaceOp) = "D($(x.alpha))"
 
 """Number operator, also available as the constant `n̂`, in an infinite dimension Fock basis."""
@@ -153,25 +158,29 @@ julia> qsimplify(S*vac, rewriter=qsimplify_fock)
 |0,π⟩
 ```
 """
-@withmetadata struct SqueezeOp <: AbstractSingleBosonGate
-    z::Number
+@withmetadata struct SqueezeOp{T<:Number} <: AbstractSingleBosonGate
+    z::T
 end
+SqueezeOp(z::T) where {T<:Number} = SqueezeOp{T}(z)
 symbollabel(x::SqueezeOp) = "S($(x.z))"
 
 """Thermal bosonic state in defined Fock basis."""
-@withmetadata struct BosonicThermalState <: AbstractSingleBosonOp
-    photons::Number
+@withmetadata struct BosonicThermalState{T<:Number} <: AbstractSingleBosonOp
+    photons::T
 end
+BosonicThermalState(photons::T) where {T<:Number} = BosonicThermalState{T}(photons)
 symbollabel(x::BosonicThermalState) = "ρₜₕ($(x.photons))"
 
 """Two-mode squeezing operator in defined Fock basis."""
-@withmetadata struct TwoSqueezeOp <: AbstractTwoBosonGate
-    z::Number
+@withmetadata struct TwoSqueezeOp{T<:Number} <: AbstractTwoBosonGate
+    z::T
 end
+TwoSqueezeOp(z::T) where {T<:Number} = TwoSqueezeOp{T}(z)
 symbollabel(x::TwoSqueezeOp) = "S₂($(x.z))"
 
 """Two-mode beamsplitter operator in defined Fock basis."""
-@withmetadata struct BeamSplitterOp <: AbstractTwoBosonGate
-    transmit::Number
+@withmetadata struct BeamSplitterOp{T<:Number} <: AbstractTwoBosonGate
+    transmit::T
 end
+BeamSplitterOp(transmit::T) where {T<:Number} = BeamSplitterOp{T}(transmit)
 symbollabel(x::BeamSplitterOp) = "B($(x.transmit))"


### PR DESCRIPTION
## Summary
- parameterize scalar expression wrapper fields so their stored coefficient/object/vector types are concrete per instance
- parameterize Fock-space states and Gaussian/Fock operators that previously stored `Number` fields
- keep public constructors such as `CoherentState(im)` and `PhaseShiftOp(pi)` working by forwarding to the inferred parametric type

## Bounty scope
This is a focused, reviewable slice of #67 rather than an attempt to finish the full ADT/Moshi direction in one PR.

## Verification
- `git diff --check`

I could not run the Julia test suite locally because `julia` is not installed in this Codex workspace.

Refs #67