### PR TITLE
Type inhomogeneous symbolic expression fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+- Give inhomogeneous symbolic expression nodes concrete field types.
+
 ## v0.4.16 - 2026-04-01
 
 - Add `QuantumClifford.Register` symbolic `apply!` methods to the `QuantumClifford` extension.

--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -86,8 +86,12 @@ macro withmetadata(strct)
     ex = quote $strct end
     if @capture(ex, (struct T_{params__} fields__ end) | (struct T_{params__} <: A_ fields__ end))
         struct_name = namify(T)
+        param_names = namify.(params)
         args = (namify(i) for i in fields if !MacroTools.isexpr(i, String, :string))
-        constructor = :($struct_name{S}($(args...)) where S = new{S}($((args..., :(Metadata()))...)))
+        constructor = :(
+            $struct_name{$(param_names...)}($(args...)) where {$(param_names...)} =
+                new{$(param_names...)}($((args..., :(Metadata()))...))
+        )
     elseif @capture(ex, struct T_ fields__ end)
         struct_name = namify(T)
         args = (namify(i) for i in fields if !MacroTools.isexpr(i, String, :string))

--- a/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
@@ -11,10 +11,17 @@ julia> A*k
 A|k⟩
 ```
 """
-@withmetadata struct SApplyKet <: Symbolic{AbstractKet}
-    op
-    ket
+@withmetadata struct SApplyKet{
+    O<:Symbolic{AbstractOperator},
+    K<:Symbolic{AbstractKet}
+} <: Symbolic{AbstractKet}
+    op::O
+    ket::K
 end
+SApplyKet(
+    op::O,
+    ket::K
+) where {O<:Symbolic{AbstractOperator},K<:Symbolic{AbstractKet}} = SApplyKet{O,K}(op, ket)
 isexpr(::SApplyKet) = true
 iscall(::SApplyKet) = true
 arguments(x::SApplyKet) = [x.op,x.ket]
@@ -47,10 +54,17 @@ julia> b*A
 ⟨b|A
 ```
 """
-@withmetadata struct SApplyBra <: Symbolic{AbstractBra}
-    bra
-    op
+@withmetadata struct SApplyBra{
+    B<:Symbolic{AbstractBra},
+    O<:Symbolic{AbstractOperator}
+} <: Symbolic{AbstractBra}
+    bra::B
+    op::O
 end
+SApplyBra(
+    bra::B,
+    op::O
+) where {B<:Symbolic{AbstractBra},O<:Symbolic{AbstractOperator}} = SApplyBra{B,O}(bra, op)
 isexpr(::SApplyBra) = true
 iscall(::SApplyBra) = true
 arguments(x::SApplyBra) = [x.bra,x.op]
@@ -83,10 +97,17 @@ julia> b*k
 ⟨b||k⟩
 ```
 """
-@withmetadata struct SBraKet <: Symbolic{Complex}
-    bra
-    ket
+@withmetadata struct SBraKet{
+    B<:Symbolic{AbstractBra},
+    K<:Symbolic{AbstractKet}
+} <: Symbolic{Complex}
+    bra::B
+    ket::K
 end
+SBraKet(
+    bra::B,
+    ket::K
+) where {B<:Symbolic{AbstractBra},K<:Symbolic{AbstractKet}} = SBraKet{B,K}(bra, ket)
 isexpr(::SBraKet) = true
 iscall(::SBraKet) = true
 arguments(x::SBraKet) = [x.bra,x.ket]
@@ -106,7 +127,7 @@ Base.:(*)(b::Symbolic{AbstractBra}, k::SZeroKet) = 0
 Base.:(*)(b::SZeroBra, k::SZeroKet) = 0
 Base.show(io::IO, x::SBraKet) = begin print(io,x.bra); print(io,x.ket) end
 Base.hash(x::SBraKet, h::UInt) = hash((head(x), arguments(x)), h)
-maketerm(::Type{SBraKet}, f, a, m) = f(a...)
+maketerm(::Type{<:SBraKet}, f, a, m) = f(a...)
 Base.isequal(x::SBraKet, y::SBraKet) = isequal(x.bra, y.bra) && isequal(x.ket, y.ket)
 
 """Symbolic outer product of a ket and a bra.
@@ -118,10 +139,17 @@ julia> k*b
 |k⟩⟨b|
 ```
 """
-@withmetadata struct SOuterKetBra <: Symbolic{AbstractOperator}
-    ket
-    bra
+@withmetadata struct SOuterKetBra{
+    K<:Symbolic{AbstractKet},
+    B<:Symbolic{AbstractBra}
+} <: Symbolic{AbstractOperator}
+    ket::K
+    bra::B
 end
+SOuterKetBra(
+    ket::K,
+    bra::B
+) where {K<:Symbolic{AbstractKet},B<:Symbolic{AbstractBra}} = SOuterKetBra{K,B}(ket, bra)
 isexpr(::SOuterKetBra) = true
 iscall(::SOuterKetBra) = true
 arguments(x::SOuterKetBra) = [x.ket,x.bra]

--- a/test/general/metadata_tests.jl
+++ b/test/general/metadata_tests.jl
@@ -29,6 +29,12 @@ using QuantumSymbolics: Metadata, @withmetadata
     end
     @test Foo4{Int}(2, 3).metadata isa Metadata
 
+    @withmetadata struct Foo4a{T<:Int, S<:Integer} <: Integer
+        a::T
+        b::S
+    end
+    @test Foo4a{Int,Int8}(2, Int8(3)).metadata isa Metadata
+
     @withmetadata struct Foo5 <: Integer
         a
     end

--- a/test/general/typed_fields_tests.jl
+++ b/test/general/typed_fields_tests.jl
@@ -1,0 +1,45 @@
+using Test
+using QuantumSymbolics
+using TermInterface: arguments, maketerm, metadata, operation
+
+@testset "Typed symbolic expression fields" begin
+    @op A
+    @ket k
+    @bra b
+
+    apply_ket = A * k
+    @test apply_ket isa SApplyKet{typeof(A),typeof(k)}
+    @test fieldtype(typeof(apply_ket), :op) === typeof(A)
+    @test fieldtype(typeof(apply_ket), :ket) === typeof(k)
+    @test isequal(
+        maketerm(typeof(apply_ket), operation(apply_ket), arguments(apply_ket), metadata(apply_ket)),
+        apply_ket
+    )
+
+    apply_bra = b * A
+    @test apply_bra isa SApplyBra{typeof(b),typeof(A)}
+    @test fieldtype(typeof(apply_bra), :bra) === typeof(b)
+    @test fieldtype(typeof(apply_bra), :op) === typeof(A)
+    @test isequal(
+        maketerm(typeof(apply_bra), operation(apply_bra), arguments(apply_bra), metadata(apply_bra)),
+        apply_bra
+    )
+
+    inner_product = b * k
+    @test inner_product isa SBraKet{typeof(b),typeof(k)}
+    @test fieldtype(typeof(inner_product), :bra) === typeof(b)
+    @test fieldtype(typeof(inner_product), :ket) === typeof(k)
+    @test isequal(
+        maketerm(typeof(inner_product), operation(inner_product), arguments(inner_product), metadata(inner_product)),
+        inner_product
+    )
+
+    outer = k * b
+    @test outer isa SOuterKetBra{typeof(k),typeof(b)}
+    @test fieldtype(typeof(outer), :ket) === typeof(k)
+    @test fieldtype(typeof(outer), :bra) === typeof(b)
+    @test isequal(
+        maketerm(typeof(outer), operation(outer), arguments(outer), metadata(outer)),
+        outer
+    )
+end


### PR DESCRIPTION
## Summary
- parameterize `SApplyKet`, `SApplyBra`, `SBraKet`, and `SOuterKetBra` over their operand types
- add concrete field annotations for those inhomogeneous symbolic expression nodes
- extend `@withmetadata` so multi-parameter structs get the same metadata constructor support
- add regression coverage for field concreteness and `maketerm` reconstruction

This is a focused first slice toward #67.

## Verification
- `julia --project=. -e 'using Pkg; Pkg.test(test_args=["general/metadata_tests", "general/typed_fields_tests", "general/sym_expressions_tests"])'`
- `julia -e 'using Pkg; Pkg.activate(; temp=true); Pkg.develop(PackageSpec(path=pwd())); Pkg.add("QuantumOpticsBase"); include("test/general/outerprod_tests.jl")'`