### PR TITLE
Type inhomogeneous symbolic product fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+- Type the fields of inhomogeneous symbolic product expressions and allow `@withmetadata` to generate constructors for multiple type parameters.
+
 ## v0.4.16 - 2026-04-01
 
 - Add `QuantumClifford.Register` symbolic `apply!` methods to the `QuantumClifford` extension.

--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -86,18 +86,29 @@ macro withmetadata(strct)
     ex = quote $strct end
     if @capture(ex, (struct T_{params__} fields__ end) | (struct T_{params__} <: A_ fields__ end))
         struct_name = namify(T)
-        args = (namify(i) for i in fields if !MacroTools.isexpr(i, String, :string))
-        constructor = :($struct_name{S}($(args...)) where S = new{S}($((args..., :(Metadata()))...)))
+        args = [namify(i) for i in fields if !MacroTools.isexpr(i, String, :string)]
+        param_names = namify.(params)
+        inferred_params = [:(typeof($arg)) for arg in args]
+        constructor = :($struct_name{$(param_names...)}($(args...)) where {$(params...)} = new{$(param_names...)}($((args..., :(Metadata()))...)))
+        outer_constructor = length(param_names) > 1 && length(param_names) == length(args) ?
+            :($struct_name($(args...)) = $struct_name{$(inferred_params...)}($(args...))) :
+            nothing
     elseif @capture(ex, struct T_ fields__ end)
         struct_name = namify(T)
-        args = (namify(i) for i in fields if !MacroTools.isexpr(i, String, :string))
+        args = [namify(i) for i in fields if !MacroTools.isexpr(i, String, :string)]
         constructor = :($struct_name($(args...)) = new($((args..., :(Metadata()))...)))
+        outer_constructor = nothing
     else @capture(ex, struct T_ end)
         struct_name = namify(T)
         constructor = :($struct_name() = new($:(Metadata())))
+        outer_constructor = nothing
     end
     struct_args = strct.args[end].args
-    push!(struct_args, constructor, :(metadata::Metadata))
+    if outer_constructor === nothing
+        push!(struct_args, constructor, :(metadata::Metadata))
+    else
+        push!(struct_args, constructor, outer_constructor, :(metadata::Metadata))
+    end
     esc(quote
     Base.@__doc__ $strct
     metadata(x::$struct_name)=x.metadata

--- a/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
@@ -11,9 +11,9 @@ julia> A*k
 A|k⟩
 ```
 """
-@withmetadata struct SApplyKet <: Symbolic{AbstractKet}
-    op
-    ket
+@withmetadata struct SApplyKet{O<:Symbolic{AbstractOperator},K<:Symbolic{AbstractKet}} <: Symbolic{AbstractKet}
+    op::O
+    ket::K
 end
 isexpr(::SApplyKet) = true
 iscall(::SApplyKet) = true
@@ -47,9 +47,9 @@ julia> b*A
 ⟨b|A
 ```
 """
-@withmetadata struct SApplyBra <: Symbolic{AbstractBra}
-    bra
-    op
+@withmetadata struct SApplyBra{B<:Symbolic{AbstractBra},O<:Symbolic{AbstractOperator}} <: Symbolic{AbstractBra}
+    bra::B
+    op::O
 end
 isexpr(::SApplyBra) = true
 iscall(::SApplyBra) = true
@@ -83,9 +83,9 @@ julia> b*k
 ⟨b||k⟩
 ```
 """
-@withmetadata struct SBraKet <: Symbolic{Complex}
-    bra
-    ket
+@withmetadata struct SBraKet{B<:Symbolic{AbstractBra},K<:Symbolic{AbstractKet}} <: Symbolic{Complex}
+    bra::B
+    ket::K
 end
 isexpr(::SBraKet) = true
 iscall(::SBraKet) = true
@@ -106,7 +106,7 @@ Base.:(*)(b::Symbolic{AbstractBra}, k::SZeroKet) = 0
 Base.:(*)(b::SZeroBra, k::SZeroKet) = 0
 Base.show(io::IO, x::SBraKet) = begin print(io,x.bra); print(io,x.ket) end
 Base.hash(x::SBraKet, h::UInt) = hash((head(x), arguments(x)), h)
-maketerm(::Type{SBraKet}, f, a, m) = f(a...)
+maketerm(::Type{<:SBraKet}, f, a, m) = f(a...)
 Base.isequal(x::SBraKet, y::SBraKet) = isequal(x.bra, y.bra) && isequal(x.ket, y.ket)
 
 """Symbolic outer product of a ket and a bra.
@@ -118,9 +118,9 @@ julia> k*b
 |k⟩⟨b|
 ```
 """
-@withmetadata struct SOuterKetBra <: Symbolic{AbstractOperator}
-    ket
-    bra
+@withmetadata struct SOuterKetBra{K<:Symbolic{AbstractKet},B<:Symbolic{AbstractBra}} <: Symbolic{AbstractOperator}
+    ket::K
+    bra::B
 end
 isexpr(::SOuterKetBra) = true
 iscall(::SOuterKetBra) = true

--- a/test/general/metadata_tests.jl
+++ b/test/general/metadata_tests.jl
@@ -36,4 +36,13 @@ using QuantumSymbolics: Metadata, @withmetadata
 
     @withmetadata struct Foo6 <: Integer end
     @test Foo6().metadata isa Metadata
+
+    @withmetadata struct Foo7{T<:Integer,U<:AbstractString}
+        a::T
+        b::U
+    end
+    foo7 = Foo7(2, "hi")
+    @test foo7.metadata isa Metadata
+    @test fieldtype(typeof(foo7), :a) === Int
+    @test fieldtype(typeof(foo7), :b) === String
 end

--- a/test/general/typed_fields_tests.jl
+++ b/test/general/typed_fields_tests.jl
@@ -1,0 +1,28 @@
+using Test
+using QuantumSymbolics
+using QuantumSymbolics: Metadata
+
+@testset "Inhomogeneous expression field types" begin
+    @op A
+    @ket k
+    @bra b
+
+    apply_ket = A * k
+    apply_bra = b * A
+    braket = b * k
+    outer = k * b
+
+    @test fieldtype(typeof(apply_ket), :op) === typeof(A)
+    @test fieldtype(typeof(apply_ket), :ket) === typeof(k)
+    @test fieldtype(typeof(apply_bra), :bra) === typeof(b)
+    @test fieldtype(typeof(apply_bra), :op) === typeof(A)
+    @test fieldtype(typeof(braket), :bra) === typeof(b)
+    @test fieldtype(typeof(braket), :ket) === typeof(k)
+    @test fieldtype(typeof(outer), :ket) === typeof(k)
+    @test fieldtype(typeof(outer), :bra) === typeof(b)
+
+    for expr in (apply_ket, apply_bra, braket, outer)
+        @test fieldtype(typeof(expr), :metadata) === Metadata
+        @test all(name -> fieldtype(typeof(expr), name) !== Any, fieldnames(typeof(expr)))
+    end
+end


### PR DESCRIPTION
Refs #67.

This is a focused slice of the struct field typing work. It updates the inhomogeneous symbolic product nodes so their argument fields are concrete per instance via type parameters:

- `SApplyKet`
- `SApplyBra`
- `SBraKet`
- `SOuterKetBra`

It also extends `@withmetadata` so multi-parameter structs get usable inferred constructors, and updates the `SBraKet` `maketerm` dispatch to match parameterized instances.

Tests:
- `julia --project=. -e "using Pkg; Pkg.test(; test_args=[\"general/metadata_tests\", \"general/typed_fields_tests\"])"`
- `julia --project=. -e "using Pkg; Pkg.test(; test_args=[\"general/expand_tests\", \"general/typed_fields_tests\", \"general/metadata_tests\"])"`
- `julia --project=. -e "using Pkg; Pkg.test(; test_args=[\"general\"])"`
