### PR TITLE
Parameterize literal symbolic basis fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## [Unreleased]
+
+- Parameterize literal symbolic object basis fields by their concrete basis type.
+
 ## v0.4.16 - 2026-04-01
 
 - Add `QuantumClifford.Register` symbolic `apply!` methods to the `QuantumClifford` extension.

--- a/src/QSymbolicsBase/literal_objects.jl
+++ b/src/QSymbolicsBase/literal_objects.jl
@@ -3,9 +3,9 @@
 ##
 
 """Symbolic bra"""
-struct SBra <: Symbolic{AbstractBra}
+struct SBra{B<:Basis} <: Symbolic{AbstractBra}
     name::Symbol
-    basis::Basis
+    basis::B
 end
 SBra(name) = SBra(name, qubit_basis)
 
@@ -30,9 +30,9 @@ macro bra(name)
 end
 
 """Symbolic ket"""
-struct SKet <: Symbolic{AbstractKet}
+struct SKet{B<:Basis} <: Symbolic{AbstractKet}
     name::Symbol
-    basis::Basis
+    basis::B
 end
 SKet(name) = SKet(name, qubit_basis)
 
@@ -57,9 +57,9 @@ macro ket(name)
 end
 
 """Symbolic operator"""
-struct SOperator <: Symbolic{AbstractOperator}
+struct SOperator{B<:Basis} <: Symbolic{AbstractOperator}
     name::Symbol
-    basis::Basis
+    basis::B
 end
 SOperator(name) = SOperator(name, qubit_basis)
 
@@ -86,9 +86,9 @@ ishermitian(x::SOperator) = false
 isunitary(x::SOperator) = false
 
 """Symbolic Hermitian operator"""
-struct SHermitianOperator <: Symbolic{AbstractOperator}
+struct SHermitianOperator{B<:Basis} <: Symbolic{AbstractOperator}
     name::Symbol
-    basis::Basis
+    basis::B
 end
 SHermitianOperator(name) = SHermitianOperator(name, qubit_basis)
 
@@ -96,9 +96,9 @@ ishermitian(::SHermitianOperator) = true
 isunitary(::SHermitianOperator) = false
 
 """Symbolic unitary operator"""
-struct SUnitaryOperator <: Symbolic{AbstractOperator}
+struct SUnitaryOperator{B<:Basis} <: Symbolic{AbstractOperator}
     name::Symbol
-    basis::Basis
+    basis::B
 end
 SUnitaryOperator(name) = SUnitaryOperator(name, qubit_basis)
 
@@ -106,9 +106,9 @@ ishermitian(::SUnitaryOperator) = false
 isunitary(::SUnitaryOperator) = true
 
 """Symbolic Hermitian and unitary operator"""
-struct SHermitianUnitaryOperator <: Symbolic{AbstractOperator}
+struct SHermitianUnitaryOperator{B<:Basis} <: Symbolic{AbstractOperator}
     name::Symbol
-    basis::Basis
+    basis::B
 end
 SHermitianUnitaryOperator(name) = SHermitianUnitaryOperator(name, qubit_basis)
 
@@ -116,9 +116,9 @@ ishermitian(::SHermitianUnitaryOperator) = true
 isunitary(::SHermitianUnitaryOperator) = true
 
 """Symbolic superoperator"""
-struct SSuperOperator <: Symbolic{AbstractSuperOperator}
+struct SSuperOperator{B<:Basis} <: Symbolic{AbstractSuperOperator}
     name::Symbol
-    basis::Basis
+    basis::B
 end
 SSuperOperator(name) = SSuperOperator(name, qubit_basis)
 macro superop(name, basis)

--- a/test/general/concrete_fields_tests.jl
+++ b/test/general/concrete_fields_tests.jl
@@ -1,0 +1,32 @@
+using Test
+using QuantumSymbolics
+
+@testset "Literal quantum object field types" begin
+    constructors = (
+        SBra,
+        SKet,
+        SOperator,
+        SHermitianOperator,
+        SUnitaryOperator,
+        SHermitianUnitaryOperator,
+        SSuperOperator,
+    )
+    bases = (SpinBasis(1//2), FockBasis(3))
+
+    for constructor in constructors
+        obj = constructor(:x)
+
+        @test fieldtype(typeof(obj), :basis) === typeof(SpinBasis(1//2))
+        @test isconcretetype(fieldtype(typeof(obj), :basis))
+        @test basis(obj) == SpinBasis(1//2)
+    end
+
+    for constructor in constructors, b in bases
+        obj = constructor(:x, b)
+
+        @test fieldtype(typeof(obj), :name) === Symbol
+        @test fieldtype(typeof(obj), :basis) === typeof(b)
+        @test isconcretetype(fieldtype(typeof(obj), :basis))
+        @test basis(obj) == b
+    end
+end


### PR DESCRIPTION
## Summary

This is a focused first slice for #67.

- Parameterizes the literal symbolic quantum object types (`SBra`, `SKet`, `SOperator`, `SHermitianOperator`, `SUnitaryOperator`, `SHermitianUnitaryOperator`, and `SSuperOperator`) by their concrete basis type.
- Keeps the public constructors and macro-created objects working with the existing default qubit basis.
- Adds regression coverage for default and explicit Spin/Fock bases to ensure the stored `basis` field is concrete.

## Validation

Docker sandbox, repo-only mount, no host secrets. Dependencies were instantiated inside `julia:1.11-bookworm`; focused test commands were run with container networking disabled.

- `julia --project=. test/general/concrete_fields_tests.jl` -> 77 passed
- `julia --project=. test/general/sym_expressions_tests.jl` -> 14 passed
- `git diff --check HEAD`

LLM assistance disclosure: prepared with Codex assistance and manually reviewed before submission.