### PR TITLE
feat: add QuantumOpticsRepr(lazy=true) support for LazyOperator output

### DIFF
--- a/docs/src/express.md
+++ b/docs/src/express.md
@@ -78,3 +78,38 @@ Operator(dim=5x5)
  0.0+0.0im  0.0+0.0im  0.0+0.0im  3.0+0.0im  0.0+0.0im
  0.0+0.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im  4.0+0.0im
 ```
+## Lazy operator output
+
+Passing `lazy=true` to `QuantumOpticsRepr` produces lazy `QuantumOpticsBase` operator types
+instead of materializing matrices immediately. Symbolic sums, products, and tensor products of
+operators map to `LazySum`, `LazyProduct`, and `LazyTensor` respectively.
+
+```@example 3
+using QuantumSymbolics, QuantumOptics # hide
+r_lazy = QuantumOpticsRepr(lazy=true)
+
+op = tensor(σˣ, IdentityOp(Z1)) + tensor(IdentityOp(Z1), σᶻ)
+lazy_op = express(op, r_lazy)
+```
+
+```@example 3
+lazy_op isa LazySum
+```
+
+The dense form agrees with the eager conversion:
+
+```@example 3
+isapprox(dense(lazy_op), express(op, QuantumOpticsRepr()))
+```
+
+`LazyTensor` is produced for tensor products, and `LazyProduct` for operator multiplication:
+
+```@example 3
+express(tensor(σˣ, σᶻ), r_lazy) isa LazyTensor
+```
+
+```@example 3
+express(tensor(σˣ, IdentityOp(Z1)) * tensor(IdentityOp(Z1), σᶻ), r_lazy) isa LazyProduct
+```
+
+The `cutoff` parameter still applies when `lazy=true`, for example `QuantumOpticsRepr(cutoff=4, lazy=true)`.

--- a/ext/QuantumOpticsExt/QuantumOpticsExt.jl
+++ b/ext/QuantumOpticsExt/QuantumOpticsExt.jl
@@ -10,6 +10,7 @@ using QuantumSymbolics:
     NumberOp, CreateOp, DestroyOp,
     FockState,
     MixedState, IdentityOp,
+    SAdd, SMulOperator, STensor,
     qubit_basis
 import QuantumSymbolics: express, express_nolookup
 using TermInterface
@@ -99,6 +100,24 @@ express_nolookup(p::PauliNoiseCPTP, ::QuantumOpticsRepr) = LazySuperSum(SpinBasi
                                                                [LazyPrePost(_id,_id),LazyPrePost(_x,_x),LazyPrePost(_y,_y),LazyPrePost(_z,_z)])
 
 express_nolookup(s::SOuterKetBra, r::QuantumOpticsRepr) = projector(express(s.ket, r), express(s.bra, r))
+
+function express_nolookup(s::SAdd{AbstractOperator}, r::QuantumOpticsRepr)
+    r.lazy || return operation(s)(express.(arguments(s), (r,))...)
+    ops = Tuple(express(obj, r) for obj in keys(s.dict))
+    LazySum(collect(values(s.dict)), ops)
+end
+
+function express_nolookup(s::SMulOperator, r::QuantumOpticsRepr)
+    r.lazy || return operation(s)(express.(arguments(s), (r,))...)
+    LazyProduct(Tuple(express(t, r) for t in s.terms))
+end
+
+function express_nolookup(s::STensor{AbstractOperator}, r::QuantumOpticsRepr)
+    r.lazy || return operation(s)(express.(arguments(s), (r,))...)
+    ops = Tuple(express(a, r) for a in s.terms)
+    b = basis(s)
+    LazyTensor(b, b, collect(1:length(ops)), ops)
+end
 
 include("should_upstream.jl")
 

--- a/test/general/qo_lazy_tests.jl
+++ b/test/general/qo_lazy_tests.jl
@@ -1,0 +1,74 @@
+using Test
+using QuantumSymbolics
+
+@testset "Lazy QuantumOpticsRepr" begin
+    using QuantumOptics
+
+    r_lazy = QuantumOpticsRepr(lazy=true)
+
+    @testset "constructor" begin
+        @test QuantumOpticsRepr().lazy == false
+        @test QuantumOpticsRepr(cutoff=4).lazy == false
+        @test QuantumOpticsRepr(4).lazy == false
+        @test QuantumOpticsRepr(lazy=true).lazy == true
+        @test QuantumOpticsRepr(cutoff=4, lazy=true).cutoff == 4
+        @test QuantumOpticsRepr(cutoff=4, lazy=true).lazy == true
+    end
+
+    Id = IdentityOp(X1)
+
+    @testset "LazySum from operator sum" begin
+        op = tensor(X, Id) + tensor(Id, Z)
+        lazy_op = express(op, r_lazy)
+        @test lazy_op isa LazySum
+        @test isapprox(dense(lazy_op), express(op, QuantumOpticsRepr()))
+    end
+
+    @testset "LazySum with scalar coefficients" begin
+        op = 2*tensor(X, Id) + 3*tensor(Id, Z)
+        lazy_op = express(op, r_lazy)
+        @test lazy_op isa LazySum
+        @test isapprox(dense(lazy_op), express(op, QuantumOpticsRepr()))
+    end
+
+    @testset "LazyProduct from operator product" begin
+        op = tensor(X, Id) * tensor(Id, Z)
+        lazy_op = express(op, r_lazy)
+        @test lazy_op isa LazyProduct
+        @test isapprox(dense(lazy_op), express(op, QuantumOpticsRepr()))
+    end
+
+    @testset "LazyTensor from tensor product" begin
+        op = tensor(X, Z)
+        lazy_op = express(op, r_lazy)
+        @test lazy_op isa LazyTensor
+        @test isapprox(dense(lazy_op), express(op, QuantumOpticsRepr()))
+    end
+
+    @testset "LazyTensor three subsystems" begin
+        op = tensor(X, Z, Y)
+        lazy_op = express(op, r_lazy)
+        @test lazy_op isa LazyTensor
+        @test isapprox(dense(lazy_op), express(op, QuantumOpticsRepr()))
+    end
+
+    @testset "sum of tensor products gives LazySum of LazyTensors" begin
+        op = tensor(X, Id) + tensor(Id, Z)
+        lazy_op = express(op, r_lazy)
+        @test lazy_op isa LazySum
+        @test all(o isa LazyTensor for o in lazy_op.operators)
+        @test isapprox(dense(lazy_op), express(op, QuantumOpticsRepr()))
+    end
+
+    @testset "lazy=false keeps eager behavior" begin
+        op = tensor(X, Id) + tensor(Id, Z)
+        @test express(op, QuantumOpticsRepr()) isa QuantumOpticsBase.Operator
+        @test express(op, QuantumOpticsRepr(lazy=false)) isa QuantumOpticsBase.Operator
+    end
+
+    @testset "cutoff still applies with lazy=true" begin
+        lazy_fock = QuantumOpticsRepr(cutoff=4, lazy=true)
+        @test express(N, lazy_fock) isa QuantumOpticsBase.Operator
+        @test size(dense(express(N, lazy_fock)).data) == (5, 5)
+    end
+end


### PR DESCRIPTION
adds express_nolookup methods for `SAdd`, `SMulOperator`, and `STensor` that return `LazySum`, `LazyProduct`, and `LazyTensor` when `r.lazy` is true. when its false, falls back to the existing eager path. includes tests and a short docs example. depends on https://github.com/qojulia/QuantumInterface.jl/pull/80

before this, `express(op, QuantumOpticsRepr())` would produce an eager `Operator`. now it produces lazy types:

```julia
using Test
using QuantumSymbolics
using QuantumOptics

r_lazy = QuantumOpticsRepr(lazy=true)

op = tensor(X, I) + tensor(I, Z)

eager_op = express(op, QuantumOpticsRepr())
lazy_op  = express(op, r_lazy)

println("lazy_op type:  ", typeof(lazy_op))
@test lazy_op isa LazySum
@test isapprox(dense(lazy_op), eager_op)
println("sum tests passed")

prod_op  = tensor(X, I) * tensor(I, Z)
lazy_prod = express(prod_op, r_lazy)

println("lazy_prod type: ", typeof(lazy_prod))
@test lazy_prod isa LazyProduct
@test isapprox(dense(lazy_prod), express(prod_op, QuantumOpticsRepr()))
println("product tests passed")
```
it produces 

```bash
lazy_op type:  LazySum{CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, Vector{Any}, Tuple{LazyTensor{CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, ComplexF64, Vector{Int64}, Tuple{Operator{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}, LinearAlgebra.Diagonal{ComplexF64, FillArrays.Ones{ComplexF64, 1, Tuple{Base.OneTo{Int64}}}}}, Operator{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}}}, LazyTensor{CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, ComplexF64, Vector{Int64}, Tuple{Operator{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}, Operator{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}, LinearAlgebra.Diagonal{ComplexF64, FillArrays.Ones{ComplexF64, 1, Tuple{Base.OneTo{Int64}}}}}}}}}
sum tests passed
lazy_prod type: LazyProduct{CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, Int64, Tuple{LazyTensor{CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, ComplexF64, Vector{Int64}, Tuple{Operator{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}, Operator{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}, LinearAlgebra.Diagonal{ComplexF64, FillArrays.Ones{ComplexF64, 1, Tuple{Base.OneTo{Int64}}}}}}}, LazyTensor{CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, ComplexF64, Vector{Int64}, Tuple{Operator{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}, LinearAlgebra.Diagonal{ComplexF64, FillArrays.Ones{ComplexF64, 1, Tuple{Base.OneTo{Int64}}}}}, Operator{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}, SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}}}}, Tuple{Ket{CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, Vector{ComplexF64}}}, Tuple{Bra{CompositeBasis{Vector{Int64}, Tuple{SpinBasis{1//2, Int64}, SpinBasis{1//2, Int64}}}, Vector{ComplexF64}}}}
product tests passed
```


Before considering your pull request ready for review and merging, make sure that all of the following are completed (**please keep the clecklist as part of your PR**):

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>

If you are submitting for a bug bounty:
- [x] I have read and followed the [AI usage and disclosure policy](https://github.com/QuantumSavory/.github/blob/main/BUG_BOUNTIES.md)

Part of https://github.com/qojulia/QuantumOptics.jl/issues/521