### PR TITLE
Add lazy=true express support for LazySum, LazyProduct, LazyTensor

### DIFF
--- a/docs/src/express.md
+++ b/docs/src/express.md
@@ -78,3 +78,35 @@ Operator(dim=5x5)
  0.0+0.0im  0.0+0.0im  0.0+0.0im  3.0+0.0im  0.0+0.0im
  0.0+0.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im  4.0+0.0im
 ```
+
+## Lazy operator output
+
+By default, [`express`](@ref) with `QuantumOpticsRepr` eagerly computes dense numerical operators. For large composite systems, this can be expensive. Passing `lazy=true` preserves the structure of symbolic expressions by producing lazy operator types from `QuantumOpticsBase` instead:
+
+- Symbolic sums produce [`LazySum`](https://docs.qojulia.org/api/#QuantumOpticsBase.LazySum)
+- Symbolic products produce [`LazyProduct`](https://docs.qojulia.org/api/#QuantumOpticsBase.LazyProduct)
+- Symbolic tensor products produce [`LazyTensor`](https://docs.qojulia.org/api/#QuantumOpticsBase.LazyTensor)
+
+```@example 3
+using QuantumSymbolics, QuantumOptics # hide
+r_lazy = QuantumOpticsRepr(lazy=true)
+
+# A simple Hamiltonian: X⊗I + I⊗Z
+ham = tensor(X, IdentityOp(X)) + tensor(IdentityOp(X), Z)
+
+lazy_ham = express(ham, r_lazy)
+```
+
+The lazy result can be converted to a dense operator with `dense`, which agrees numerically with the eager version:
+
+```@example 3
+eager_ham = express(ham, QuantumOpticsRepr())
+isapprox(dense(lazy_ham), eager_ham)
+```
+
+The `cutoff` option still applies to Fock-space objects when `lazy=true`:
+
+```@example 3
+r_lazy4 = QuantumOpticsRepr(cutoff=4, lazy=true)
+express(N, r_lazy4) |> dense
+```

--- a/ext/QuantumOpticsExt/QuantumOpticsExt.jl
+++ b/ext/QuantumOpticsExt/QuantumOpticsExt.jl
@@ -10,7 +10,9 @@ using QuantumSymbolics:
     NumberOp, CreateOp, DestroyOp,
     FockState,
     MixedState, IdentityOp,
-    qubit_basis
+    qubit_basis,
+    SAddOperator, SScaledOperator, SMulOperator, STensorOperator,
+    SCommutator, SAnticommutator
 import QuantumSymbolics: express, express_nolookup
 using TermInterface
 using TermInterface: isexpr, head, operation, arguments, metadata
@@ -101,5 +103,77 @@ express_nolookup(p::PauliNoiseCPTP, ::QuantumOpticsRepr) = LazySuperSum(SpinBasi
 express_nolookup(s::SOuterKetBra, r::QuantumOpticsRepr) = projector(express(s.ket, r), express(s.bra, r))
 
 include("should_upstream.jl")
+
+##
+# Lazy express methods for QuantumOpticsRepr(lazy=true)
+#
+# When lazy=true, composite operator expressions (sums, products, tensor products)
+# are expressed using LazySum, LazyProduct, and LazyTensor instead of eager dense
+# operators. Individual (leaf) operators are still expressed eagerly.
+##
+
+# Symbolic operator addition → LazySum
+function express_nolookup(x::SAddOperator, r::QuantumOpticsRepr)
+    r.lazy || return +(express.(arguments(x), (r,))...)
+    factors = ComplexF64[]
+    ops = []
+    for a in arguments(x)
+        if a isa SScaledOperator
+            push!(factors, ComplexF64(a.coeff))
+            push!(ops, express(a.obj, r))
+        else
+            push!(factors, one(ComplexF64))
+            push!(ops, express(a, r))
+        end
+    end
+    LazySum(factors, ops)
+end
+
+# Symbolic operator multiplication → LazyProduct
+function express_nolookup(x::SMulOperator, r::QuantumOpticsRepr)
+    r.lazy || return *(express.(arguments(x), (r,))...)
+    expressed = Tuple(express.(arguments(x), (r,)))
+    LazyProduct(expressed)
+end
+
+# Symbolic tensor product of operators → LazyTensor
+function express_nolookup(x::STensorOperator, r::QuantumOpticsRepr)
+    r.lazy || return ⊗(express.(arguments(x), (r,))...)
+    args = arguments(x)
+    expressed = [express(t, r) for t in args]
+    bl = tensor([op.basis_l for op in expressed]...)
+    br = tensor([op.basis_r for op in expressed]...)
+    # Only include non-identity subsystems for efficient LazyTensor
+    indices = Int[]
+    nontrivial = []
+    for (i, (sym_arg, num_op)) in enumerate(zip(args, expressed))
+        if !(sym_arg isa IdentityOp)
+            push!(indices, i)
+            push!(nontrivial, num_op)
+        end
+    end
+    if isempty(nontrivial)
+        return identityoperator(bl)
+    end
+    LazyTensor(bl, br, indices, Tuple(nontrivial))
+end
+
+# Symbolic commutator [A, B] = AB - BA → LazySum of LazyProducts
+function express_nolookup(x::SCommutator, r::QuantumOpticsRepr)
+    r.lazy || return commutator(express(x.op1, r), express(x.op2, r))
+    a = express(x.op1, r)
+    b = express(x.op2, r)
+    LazySum([one(ComplexF64), -one(ComplexF64)],
+            [LazyProduct(a, b), LazyProduct(b, a)])
+end
+
+# Symbolic anticommutator {A, B} = AB + BA → LazySum of LazyProducts
+function express_nolookup(x::SAnticommutator, r::QuantumOpticsRepr)
+    r.lazy || return anticommutator(express(x.op1, r), express(x.op2, r))
+    a = express(x.op1, r)
+    b = express(x.op2, r)
+    LazySum([one(ComplexF64), one(ComplexF64)],
+            [LazyProduct(a, b), LazyProduct(b, a)])
+end
 
 end

--- a/test/general/lazy_express_tests.jl
+++ b/test/general/lazy_express_tests.jl
@@ -1,0 +1,123 @@
+using Test
+using QuantumSymbolics
+using QuantumOptics
+
+@testset "Lazy express" begin
+    r_lazy = QuantumOpticsRepr(lazy=true)
+    r_eager = QuantumOpticsRepr()
+
+    # QuantumOpticsRepr constructor backward compatibility
+    @test QuantumOpticsRepr().lazy == false
+    @test QuantumOpticsRepr().cutoff == 2
+    @test QuantumOpticsRepr(cutoff=4).lazy == false
+    @test QuantumOpticsRepr(cutoff=4, lazy=true).lazy == true
+    @test QuantumOpticsRepr(cutoff=4, lazy=true).cutoff == 4
+
+    # LazySum from symbolic operator addition
+    @testset "LazySum" begin
+        op = X + Z
+        lazy_op = express(op, r_lazy)
+        eager_op = express(op, r_eager)
+        @test lazy_op isa LazySum
+        @test isapprox(dense(lazy_op), eager_op)
+
+        # Sum with coefficients
+        op2 = 2*X + 3im*Z
+        lazy_op2 = express(op2, r_lazy)
+        eager_op2 = express(op2, r_eager)
+        @test lazy_op2 isa LazySum
+        @test isapprox(dense(lazy_op2), eager_op2)
+
+        # Sum of tensor products (Hamiltonian-like)
+        ham = tensor(X, IdentityOp(X)) + tensor(IdentityOp(X), Z)
+        lazy_ham = express(ham, r_lazy)
+        eager_ham = express(ham, r_eager)
+        @test lazy_ham isa LazySum
+        @test isapprox(dense(lazy_ham), eager_ham)
+    end
+
+    # LazyProduct from symbolic operator multiplication
+    @testset "LazyProduct" begin
+        op = X * Z
+        lazy_op = express(op, r_lazy)
+        eager_op = express(op, r_eager)
+        @test lazy_op isa LazyProduct
+        @test isapprox(dense(lazy_op), eager_op)
+
+        # Product of tensor products
+        prod_op = tensor(X, IdentityOp(X)) * tensor(IdentityOp(X), Z)
+        lazy_prod = express(prod_op, r_lazy)
+        eager_prod = express(prod_op, r_eager)
+        @test lazy_prod isa LazyProduct
+        @test isapprox(dense(lazy_prod), eager_prod)
+    end
+
+    # LazyTensor from symbolic tensor products
+    @testset "LazyTensor" begin
+        op = tensor(X, Z)
+        lazy_op = express(op, r_lazy)
+        eager_op = express(op, r_eager)
+        @test lazy_op isa LazyTensor
+        @test isapprox(dense(lazy_op), eager_op)
+
+        # Tensor with identity (should filter identity out in LazyTensor)
+        op2 = tensor(X, IdentityOp(X))
+        lazy_op2 = express(op2, r_lazy)
+        eager_op2 = express(op2, r_eager)
+        @test lazy_op2 isa LazyTensor
+        @test isapprox(dense(lazy_op2), eager_op2)
+    end
+
+    # Commutator
+    @testset "Commutator" begin
+        c = commutator(X, Z)
+        lazy_c = express(c, r_lazy)
+        eager_c = express(c, r_eager)
+        @test lazy_c isa LazySum
+        @test isapprox(dense(lazy_c), eager_c)
+    end
+
+    # Anticommutator
+    @testset "Anticommutator" begin
+        ac = anticommutator(X, Z)
+        lazy_ac = express(ac, r_lazy)
+        eager_ac = express(ac, r_eager)
+        @test lazy_ac isa LazySum
+        @test isapprox(dense(lazy_ac), eager_ac)
+    end
+
+    # Cutoff still applies to Fock-space objects with lazy=true
+    @testset "Cutoff with lazy" begin
+        r_lazy4 = QuantumOpticsRepr(cutoff=4, lazy=true)
+        op = N + Create
+        lazy_op = express(op, r_lazy4)
+        eager_op = express(op, QuantumOpticsRepr(cutoff=4))
+        @test lazy_op isa LazySum
+        @test isapprox(dense(lazy_op), eager_op)
+    end
+
+    # Eager mode is unchanged
+    @testset "Eager unchanged" begin
+        op = X + Z
+        eager_op = express(op, r_eager)
+        @test !(eager_op isa LazySum)
+
+        prod_op = X * Z
+        eager_prod = express(prod_op, r_eager)
+        @test !(eager_prod isa LazyProduct)
+    end
+
+    # Minimal example from the issue
+    @testset "Issue minimal example" begin
+        op = tensor(X, IdentityOp(X)) + tensor(IdentityOp(X), Z)
+        eager_op = express(op, QuantumOpticsRepr())
+        lazy_op = express(op, r_lazy)
+        @test lazy_op isa LazySum
+        @test isapprox(dense(lazy_op), eager_op)
+
+        prod_op = tensor(X, IdentityOp(X)) * tensor(IdentityOp(X), Z)
+        lazy_prod = express(prod_op, r_lazy)
+        @test lazy_prod isa LazyProduct
+        @test isapprox(dense(lazy_prod), express(prod_op, QuantumOpticsRepr()))
+    end
+end


### PR DESCRIPTION
Closes qojulia/QuantumOptics.jl#521

Adds opt-in lazy operator output when expressing symbolic quantum objects with `QuantumOpticsRepr(lazy=true)`. Instead of eagerly computing dense matrices, composite expressions are wrapped in the corresponding `QuantumOpticsBase` lazy types.

**Changes:**

`ext/QuantumOpticsExt/QuantumOpticsExt.jl` — new `express_nolookup` methods that intercept composite operator expressions when `lazy=true`:
- Operator sums (`SAddOperator`) → `LazySum`
- Operator products (`SMulOperator`) → `LazyProduct`
- Operator tensor products (`STensorOperator`) → `LazyTensor`
- Commutators (`SCommutator`) → `LazySum` of `LazyProduct`s
- Anticommutators (`SAnticommutator`) → `LazySum` of `LazyProduct`s

When `lazy=false` (the default), all methods fall through to existing eager behavior — nothing changes for current users. Leaf operators (gates, Fock operators, etc.) are still expressed eagerly; laziness only affects how they're combined. The `LazyTensor` method filters out `IdentityOp` subsystems so only non-trivial operators are stored. `cutoff` continues to work — `QuantumOpticsRepr(cutoff=4, lazy=true)` still applies the cutoff to Fock-space bases.

`test/general/lazy_express_tests.jl` — tests for all five expression types, coefficient handling, cutoff with lazy, eager backward compatibility, and the minimal example from the issue.

`docs/src/express.md` — documents the `lazy=true` option with examples.

**Depends on:** qojulia/QuantumInterface.jl#84 (adds `lazy::Bool=false` field to `QuantumOpticsRepr`)

**CHANGELOG:** Added `QuantumOpticsRepr(lazy=true)` support for expressing symbolic operator sums, products, tensor products, commutators, and anticommutators as `LazySum`, `LazyProduct`, and `LazyTensor`.

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>

If you are submitting for a bug bounty:
- [x] I have read and followed the [AI usage and disclosure policy](https://github.com/QuantumSavory/.github/blob/main/BUG_BOUNTIES.md)