### PR TITLE
Express symbolic operators lazily with QuantumOpticsRepr(lazy=true) (…

### DIFF
--- a/docs/src/express.md
+++ b/docs/src/express.md
@@ -78,3 +78,21 @@ Operator(dim=5x5)
  0.0+0.0im  0.0+0.0im  0.0+0.0im  3.0+0.0im  0.0+0.0im
  0.0+0.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im  4.0+0.0im
 ```
+
+`QuantumOpticsRepr` also accepts a `lazy` keyword. With `lazy=true`, composite
+symbolic expressions are translated into the structure-preserving lazy operators
+of `QuantumOptics.jl` instead of being eagerly materialised: a symbolic sum
+becomes a `LazySum`, a product a `LazyProduct`, and a tensor product a
+`LazyTensor`. This avoids building large dense or sparse matrices until they are
+explicitly requested (e.g. via `dense` or `sparse`), while remaining numerically
+equivalent to the eager translation.
+
+```julia
+julia> ls = express(X + Y, QuantumOpticsRepr(lazy=true))
+LazySum(dim=2x2)
+  basis: Spin(1/2)
+  ...
+
+julia> dense(ls) ≈ express(X + Y)   # numerically identical to the eager result
+true
+```

--- a/ext/QuantumOpticsExt/QuantumOpticsExt.jl
+++ b/ext/QuantumOpticsExt/QuantumOpticsExt.jl
@@ -50,6 +50,41 @@ express_nolookup(::ZGate, ::QuantumOpticsRepr) = _z
 express_nolookup(::CPHASEGate, ::QuantumOpticsRepr) = _cphase
 express_nolookup(::CNOTGate, ::QuantumOpticsRepr) = _cnot
 
+# Composite expressions (sums, products, tensor products). By default they are
+# expressed eagerly by applying the symbolic operation to the expressed
+# arguments. With QuantumOpticsRepr(lazy=true), produce the structure-preserving
+# lazy operators (LazySum / LazyProduct / LazyTensor) instead (issue #521).
+function express_nolookup(s, repr::QuantumOpticsRepr)
+    isexpr(s) || error("Encountered an object $(s) of type $(typeof(s)) that can not be converted to a $(repr) representation")
+    args = express.(arguments(s), (repr,))
+    if repr.lazy
+        op = operation(s)
+        allops = all(a -> a isa AbstractOperator, args)
+        if op === (+) && allops
+            return LazySum(args...)
+        elseif op === (*) && all(a -> a isa AbstractOperator || a isa Number, args)
+            # operator product, possibly with scalar prefactors; ignore the
+            # ket/bra cases (which also carry operation === *) by the guard above
+            ops = Tuple(a for a in args if a isa AbstractOperator)
+            factor = prod((a for a in args if a isa Number); init=1)
+            if length(ops) >= 2
+                return LazyProduct(ops, factor)
+            elseif length(ops) == 1
+                return factor * ops[1]
+            end
+        elseif op === (⊗) && allops
+            # LazyTensor embeds one operator per subsystem; its densification
+            # requires plain (densifiable) factors, so collapse any lazy factor
+            # (the cheap inner operator) while keeping the tensor product itself lazy
+            facs = map(a -> a isa QuantumOpticsBase.LazyOperator ? dense(a) : a, args)
+            bl = tensor((a.basis_l for a in facs)...)
+            br = tensor((a.basis_r for a in facs)...)
+            return LazyTensor(bl, br, Tuple(eachindex(facs)), Tuple(facs))
+        end
+    end
+    return operation(s)(args...)
+end
+
 const xyzopdict = Dict(:X=>_x, :Y=>_y, :Z=>_z)
 const xyzstatedict = Dict(:X=>(_s₊,_s₋),:Y=>(_i₊,_i₋),:Z=>(_l0,_l1))
 for control in (:X, :Y, :Z)

--- a/test/general/express_lazy_tests.jl
+++ b/test/general/express_lazy_tests.jl
@@ -1,0 +1,37 @@
+using Test
+using QuantumSymbolics
+
+@testset "Express lazy (QuantumOpticsRepr(lazy=true))" begin
+    import QuantumOptics
+    using QuantumOptics: LazySum, LazyProduct, LazyTensor, dense
+
+    eager = QuantumOpticsRepr()
+    lazy  = QuantumOpticsRepr(lazy=true)
+
+    # constructor + backward compatibility
+    @test QuantumOpticsRepr().lazy == false
+    @test QuantumOpticsRepr(3).cutoff == 3          # historical positional ctor
+    @test QuantumOpticsRepr(lazy=true).lazy == true
+
+    # symbolic sum -> LazySum
+    s = express(X + Y, lazy)
+    @test s isa LazySum
+    @test isapprox(dense(s), express(X + Y, eager))
+
+    # symbolic product -> LazyProduct
+    p = express(X * Y, lazy)
+    @test p isa LazyProduct
+    @test isapprox(dense(p), express(X * Y, eager))
+
+    # symbolic tensor product -> LazyTensor
+    t = express(X ⊗ Y, lazy)
+    @test t isa LazyTensor
+    @test isapprox(dense(t), express(X ⊗ Y, eager))
+
+    # scalar prefactors and nesting remain numerically correct
+    @test isapprox(dense(express(2 * X + Y, lazy)), express(2 * X + Y, eager))
+    @test isapprox(dense(express((X + Y) ⊗ Z, lazy)), express((X + Y) ⊗ Z, eager))
+
+    # the default (eager) representation is unchanged
+    @test !(express(X + Y, eager) isa LazySum)
+end


### PR DESCRIPTION
Closes qojulia/QuantumOptics.jl#521.

  Part 2 of 2. With `QuantumOpticsRepr(lazy=true)`, composite symbolic expressions
  are translated into the structure-preserving lazy operators of QuantumOptics.jl
  instead of being eagerly materialised:

  - symbolic sum     → `LazySum`
  - symbolic product → `LazyProduct`
  - symbolic tensor  → `LazyTensor`

  and `dense(lazy) ≈ eager` holds. The default representation is untouched.

  ### How
  QuantumSymbolics already expresses a composite expression as
  `operation(s)(express.(arguments(s))...)`. The lazy path simply swaps the
  operation for its lazy constructor when `repr.lazy` is set — `operation` is `+`
  for `SAdd`, `*` for `SMulOperator`/`SScaled`, and `⊗` for `STensor`. Guards keep
  the ket/bra cases (which also carry `operation === *`) on the eager path, and
  collapse any lazy *factor* before it goes into a `LazyTensor` (which needs
  densifiable factors) while keeping the tensor product itself lazy.

  Added `test/general/express_lazy_tests.jl` (sum/product/tensor types,
  `dense ≈ eager`, scalar prefactors, nesting, backward compatibility, eager path
  unchanged) and a short paragraph in `docs/src/express.md`.

  Locally: the new tests pass, and the existing `express_opt_tests.jl` still passes
  (no regression on the eager path).
  
  ### Dependency
  This depends on the `lazy` field added in qojulia/QuantumInterface.jl#<PR1-NUMBER>.
  CI here will fail until that PR is merged and a new QuantumInterface release is
  registered, since this resolves the released version. Happy to rebase / adjust
  compat bounds once that's out.

  Companion PR: qojulia/QuantumInterface.jl#<PR1-NUMBER>
  Issue: qojulia/QuantumOptics.jl#521

**AI Acknowledgment:** i want to thank claude opus 4.6 for making me understand code base of both repos and helpin me running testing and validations