### PR TITLE
Concretize symbolic struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+- Concretely type core symbolic struct fields and add regression coverage for untyped package-owned fields.
+
 ## v0.4.16 - 2026-04-01
 
 - Add `QuantumClifford.Register` symbolic `apply!` methods to the `QuantumClifford` extension.

--- a/ext/QuantumCliffordExt/QuantumCliffordExt.jl
+++ b/ext/QuantumCliffordExt/QuantumCliffordExt.jl
@@ -59,9 +59,9 @@ express_nolookup(op::SScaledOperator, r::CliffordRepr, u::UseAsObservable) = arg
 express_nolookup(x::SMulOperator,     r::CliffordRepr, u::UseAsObservable) = (*)((express(t,r,u) for t in arguments(x))...)
 express_nolookup(op, ::CliffordRepr, ::UseAsObservable) = error("Can not convert $(op) into a `PauliOperator`, which is the only observable that can be computed for QuantumClifford objects. Consider defining `express_nolookup(op, ::CliffordRepr, ::UseAsObservable)::PauliOperator` for this object.")
 
-struct QCRandomSampler # TODO specify types
-    operators # union of QCRandomSampler and MixedDestabilizer
-    weights
+struct QCRandomSampler{O<:AbstractVector,W<:AbstractVector}
+    operators::O # union of QCRandomSampler and MixedDestabilizer
+    weights::W
 end
 function express_nolookup(x::SAddOperator, repr::CliffordRepr)
     weights = collect(values(x.dict))
@@ -84,8 +84,8 @@ function express_nolookup(x::MixedState, ::CliffordRepr)
 end
 express_nolookup(x::SProjector, repr::CliffordRepr) = express_nolookup(x.ket, repr)
 
-struct QCGateSequence <: QuantumClifford.AbstractSymbolicOperator
-    gates # TODO constructor that flattens nested QCGateSequence
+struct QCGateSequence{G<:AbstractVector} <: QuantumClifford.AbstractSymbolicOperator
+    gates::G # TODO constructor that flattens nested QCGateSequence
 end
 
 function QuantumClifford.apply!(

--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -144,9 +144,9 @@ Base.isequal(::Symbolic{Complex}, ::SymQObj) = false
 const SymScalar = Symbolic{Complex}
 
 """Symbolic scaled scalar expression: `coeff * obj` where obj is a `Symbolic{Complex}`."""
-struct SScaledComplex <: Symbolic{Complex}
-    coeff
-    obj
+struct SScaledComplex{C<:Union{Number,SymbolicUtils.BasicSymbolic,SymScalar},O<:SymScalar} <: Symbolic{Complex}
+    coeff::C
+    obj::O
 end
 isexpr(::SScaledComplex) = true
 iscall(::SScaledComplex) = true
@@ -155,14 +155,14 @@ operation(::SScaledComplex) = *
 head(::SScaledComplex) = :*
 children(x::SScaledComplex) = [:*, x.coeff, x.obj]
 metadata(::SScaledComplex) = nothing
-maketerm(::Type{SScaledComplex}, f, a, m) = f(a...)
+maketerm(::Type{<:SScaledComplex}, f, a, m) = f(a...)
 Base.show(io::IO, x::SScaledComplex) = print(io, "($(x.coeff))$(x.obj)")
 Base.hash(x::SScaledComplex, h::UInt) = hash((head(x), x.coeff, x.obj), h)
 Base.isequal(x::SScaledComplex, y::SScaledComplex) = isequal(x.coeff, y.coeff) && isequal(x.obj, y.obj)
 
 """Symbolic sum of scalar expressions."""
-struct SAddComplex <: Symbolic{Complex}
-    terms
+struct SAddComplex{T<:AbstractVector} <: Symbolic{Complex}
+    terms::T
 end
 isexpr(::SAddComplex) = true
 iscall(::SAddComplex) = true
@@ -171,14 +171,14 @@ operation(::SAddComplex) = +
 head(::SAddComplex) = :+
 children(x::SAddComplex) = [:+; x.terms]
 metadata(::SAddComplex) = nothing
-maketerm(::Type{SAddComplex}, f, a, m) = f(a...)
+maketerm(::Type{<:SAddComplex}, f, a, m) = f(a...)
 Base.show(io::IO, x::SAddComplex) = print(io, join(map(string, x.terms), "+"))
 Base.hash(x::SAddComplex, h::UInt) = hash((:+, Set(x.terms)), h)
 Base.isequal(x::SAddComplex, y::SAddComplex) = Set(x.terms) == Set(y.terms)
 
 """Symbolic product of scalar expressions."""
-struct SMulComplex <: Symbolic{Complex}
-    terms
+struct SMulComplex{T<:AbstractVector} <: Symbolic{Complex}
+    terms::T
 end
 isexpr(::SMulComplex) = true
 iscall(::SMulComplex) = true
@@ -187,7 +187,7 @@ operation(::SMulComplex) = *
 head(::SMulComplex) = :*
 children(x::SMulComplex) = [:*; x.terms]
 metadata(::SMulComplex) = nothing
-maketerm(::Type{SMulComplex}, f, a, m) = f(a...)
+maketerm(::Type{<:SMulComplex}, f, a, m) = f(a...)
 Base.show(io::IO, x::SMulComplex) = print(io, join(map(string, x.terms), "*"))
 Base.hash(x::SMulComplex, h::UInt) = hash((:*, x.terms), h)
 Base.isequal(x::SMulComplex, y::SMulComplex) = isequal(x.terms, y.terms)

--- a/src/QSymbolicsBase/basic_ops_homogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_homogeneous.jl
@@ -20,8 +20,8 @@ julia> 2*A
 ```
 """
 @withmetadata struct SScaled{T<:QObj} <: Symbolic{T}
-    coeff
-    obj
+    coeff::Union{Number,SymbolicUtils.BasicSymbolic,Symbolic{Complex}}
+    obj::Symbolic{T}
 end
 isexpr(::SScaled) = true
 iscall(::SScaled) = true
@@ -105,14 +105,14 @@ julia> k₁ + k₂
 ```
 """
 @withmetadata struct SAdd{T<:QObj} <: Symbolic{T}
-    dict
-    _set_precomputed
-    _arguments_precomputed
+    dict::Dict{Any,Any}
+    _set_precomputed::Set{Any}
+    _arguments_precomputed::Vector{Any}
 end
 function SAdd{S}(d) where S
     isempty(d) && return SZero{S}()
-    terms = [c*obj for (obj,c) in d]
-    length(d)==1 ? first(terms) : SAdd{S}(d,Set(terms),terms)
+    terms = Any[c*obj for (obj,c) in d]
+    length(d)==1 ? first(terms) : SAdd{S}(Dict{Any,Any}(d),Set{Any}(terms),terms)
 end
 isexpr(::SAdd) = true
 iscall(::SAdd) = true
@@ -156,8 +156,9 @@ AB
 ```
 """
 @withmetadata struct SMulOperator <: Symbolic{AbstractOperator}
-    terms
+    terms::Vector{Any}
 end
+SMulOperator(term::Symbolic{AbstractOperator}, terms::Symbolic{AbstractOperator}...) = SMulOperator(Any[term, terms...])
 isexpr(::SMulOperator) = true
 iscall(::SMulOperator) = true
 arguments(x::SMulOperator) = x.terms
@@ -200,7 +201,7 @@ A⊗B
 ```
 """
 @withmetadata struct STensor{T<:QObj} <: Symbolic{T}
-    terms
+    terms::Vector{Any}
 end
 isexpr(::STensor) = true
 iscall(::STensor) = true

--- a/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
@@ -12,8 +12,8 @@ A|k⟩
 ```
 """
 @withmetadata struct SApplyKet <: Symbolic{AbstractKet}
-    op
-    ket
+    op::Symbolic{AbstractOperator}
+    ket::Symbolic{AbstractKet}
 end
 isexpr(::SApplyKet) = true
 iscall(::SApplyKet) = true
@@ -48,8 +48,8 @@ julia> b*A
 ```
 """
 @withmetadata struct SApplyBra <: Symbolic{AbstractBra}
-    bra
-    op
+    bra::Symbolic{AbstractBra}
+    op::Symbolic{AbstractOperator}
 end
 isexpr(::SApplyBra) = true
 iscall(::SApplyBra) = true
@@ -84,8 +84,8 @@ julia> b*k
 ```
 """
 @withmetadata struct SBraKet <: Symbolic{Complex}
-    bra
-    ket
+    bra::Symbolic{AbstractBra}
+    ket::Symbolic{AbstractKet}
 end
 isexpr(::SBraKet) = true
 iscall(::SBraKet) = true
@@ -119,8 +119,8 @@ julia> k*b
 ```
 """
 @withmetadata struct SOuterKetBra <: Symbolic{AbstractOperator}
-    ket
-    bra
+    ket::Symbolic{AbstractKet}
+    bra::Symbolic{AbstractBra}
 end
 isexpr(::SOuterKetBra) = true
 iscall(::SOuterKetBra) = true

--- a/src/QSymbolicsBase/basic_superops.jl
+++ b/src/QSymbolicsBase/basic_superops.jl
@@ -17,7 +17,7 @@ A₁ρA₁†+A₂ρA₂†+A₃ρA₃†
 ```
 """
 @withmetadata struct KrausRepr <: Symbolic{AbstractSuperOperator}
-    krausops
+    krausops::Vector{Any}
 end
 isexpr(::KrausRepr) = true
 iscall(::KrausRepr) = true
@@ -25,7 +25,7 @@ arguments(x::KrausRepr) = x.krausops
 operation(x::KrausRepr) = kraus
 head(x::KrausRepr) = :kraus
 children(x::KrausRepr) = [:kraus; x.krausops]
-kraus(xs::Symbolic{AbstractOperator}...) = KrausRepr(collect(xs))
+kraus(xs::Symbolic{AbstractOperator}...) = KrausRepr(Any[xs...])
 basis(x::KrausRepr) = basis(first(x.krausops))
 Base.:(*)(sop::KrausRepr, op::Symbolic{AbstractOperator}) = (+)((i*op*dagger(i) for i in sop.krausops)...)
 Base.:(*)(sop::KrausRepr, k::Symbolic{AbstractKet}) = (+)((i*SProjector(k)*dagger(i) for i in sop.krausops)...)
@@ -47,8 +47,8 @@ S[A]
 ```
 """
 @withmetadata struct SSuperOpApply <: Symbolic{AbstractOperator}
-    sop
-    op
+    sop::Symbolic{AbstractSuperOperator}
+    op::Symbolic{AbstractOperator}
 end
 isexpr(::SSuperOpApply) = true
 iscall(::SSuperOpApply) = true

--- a/src/QSymbolicsBase/linalg.jl
+++ b/src/QSymbolicsBase/linalg.jl
@@ -21,8 +21,8 @@ julia> commutator(A, A)
 ```
 """
 @withmetadata struct SCommutator <: Symbolic{AbstractOperator}
-    op1
-    op2
+    op1::Symbolic{AbstractOperator}
+    op2::Symbolic{AbstractOperator}
 end
 isexpr(::SCommutator) = true
 iscall(::SCommutator) = true
@@ -55,8 +55,8 @@ julia> anticommutator(A, B)
 ```
 """
 @withmetadata struct SAnticommutator <: Symbolic{AbstractOperator}
-    op1
-    op2
+    op1::Symbolic{AbstractOperator}
+    op2::Symbolic{AbstractOperator}
 end
 isexpr(::SAnticommutator) = true
 iscall(::SAnticommutator) = true
@@ -92,7 +92,7 @@ julia> conj(k)
 ```
 """
 @withmetadata struct SConjugate{T<:QObj} <: Symbolic{T}
-    obj
+    obj::Symbolic{T}
 end
 isexpr(::SConjugate) = true
 iscall(::SConjugate) = true
@@ -171,7 +171,7 @@ julia> transpose(k)
 ```
 """
 @withmetadata struct STranspose{T<:QObj} <: Symbolic{T}
-    obj
+    obj::Symbolic{T}
 end
 isexpr(::STranspose) = true
 iscall(::STranspose) = true
@@ -223,7 +223,7 @@ U⁻¹
 ```
 """
 @withmetadata struct SDagger{T<:QObj} <: Symbolic{T}
-    obj
+    obj::SymQObj
 end
 isexpr(::SDagger) = true
 iscall(::SDagger) = true
@@ -350,7 +350,7 @@ julia> ptrace(mixed_state, 2)
 ```
 """
 @withmetadata struct SPartialTrace <: Symbolic{AbstractOperator}
-    obj
+    obj::Symbolic{AbstractOperator}
     sys::Int
 end
 isexpr(::SPartialTrace) = true

--- a/src/QSymbolicsBase/predefined_CPTP.jl
+++ b/src/QSymbolicsBase/predefined_CPTP.jl
@@ -40,23 +40,23 @@ Operator(dim=2x2)
  0.0+0.0im  0.5+0.0im
 ```"""
 @withmetadata struct PauliNoiseCPTP <: NoiseCPTP
-    px
-    py
-    pz
+    px::Real
+    py::Real
+    pz::Real
 end
 basis(x::PauliNoiseCPTP) = SpinBasis(1//2)
 symbollabel(x::PauliNoiseCPTP) = "𝒫"
 
 """Single-qubit dephasing CPTP map"""
 @withmetadata struct DephasingCPTP <: NoiseCPTP
-    p
+    p::Real
 end
 basis(x::DephasingCPTP) = SpinBasis(1//2)
 symbollabel(x::DephasingCPTP) = "𝒟𝓅𝒽"
 
 """Single-qubit depolarization CPTP map"""
 @withmetadata struct DepolarizationCPTP <: NoiseCPTP
-    p
+    p::Real
     basis::Basis
 end
 symbollabel(x::DepolarizationCPTP) = "𝒟ℯ𝓅ℴ𝓁"

--- a/test/general/field_type_tests.jl
+++ b/test/general/field_type_tests.jl
@@ -1,0 +1,52 @@
+using Test
+using QuantumSymbolics
+using Gabs
+using QuantumClifford
+using QuantumOptics
+using QuantumToolbox
+
+function own_struct_types(mod)
+    types = []
+    for name in names(mod; all=true, imported=false)
+        occursin("#", string(name)) && continue
+        isdefined(mod, name) || continue
+        T = getfield(mod, name)
+        (T isa DataType || T isa UnionAll) || continue
+        T_unwrapped = Base.unwrap_unionall(T)
+        Base.typename(T_unwrapped).module === mod || continue
+        fields = try
+            fieldnames(T_unwrapped)
+        catch
+            continue
+        end
+        isempty(fields) && continue
+        push!(types, T)
+    end
+    types
+end
+
+@testset "struct field types" begin
+    modules = [
+        QuantumSymbolics,
+        Base.get_extension(QuantumSymbolics, :GabsExt),
+        Base.get_extension(QuantumSymbolics, :QuantumCliffordExt),
+        Base.get_extension(QuantumSymbolics, :QuantumOpticsExt),
+        Base.get_extension(QuantumSymbolics, :QuantumToolboxExt),
+        Base.get_extension(QuantumSymbolics, :MixedCliffordOpticsExt),
+    ]
+
+    for mod in modules
+        @test mod !== nothing
+        any_fields = []
+        for T in own_struct_types(mod)
+            T_unwrapped = Base.unwrap_unionall(T)
+            for name in fieldnames(T_unwrapped)
+                name === :metadata && continue
+                if fieldtype(T_unwrapped, name) === Any
+                    push!(any_fields, (mod, T, name))
+                end
+            end
+        end
+        @test isempty(any_fields)
+    end
+end

--- a/test/general/sym_expressions_tests.jl
+++ b/test/general/sym_expressions_tests.jl
@@ -1,5 +1,6 @@
 using Test
 using QuantumSymbolics
+using TermInterface: arguments, maketerm, metadata, operation
 
 @testset "Sym expressions" begin
     @test +(Z1) == Z1
@@ -25,4 +26,21 @@ using QuantumSymbolics
     @test isequal(A+B-A+B, 2B)
     @test isequal(2A-3B+2(A+B), 4A-B)
     @test isequal(2A-3B+2(A+2B), 4A+B)
+
+    @testset "typed symbolic operation reconstruction" begin
+        trace_a = tr(A)
+        trace_b = tr(B)
+
+        for scalar_expr in (2 * trace_a, trace_a + trace_b, trace_a * trace_b)
+            rebuilt = maketerm(
+                typeof(scalar_expr),
+                operation(scalar_expr),
+                arguments(scalar_expr),
+                metadata(scalar_expr),
+            )
+            @test isequal(rebuilt, scalar_expr)
+        end
+
+        @test isequal(SMulOperator(A, B), A * B)
+    end
 end

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -8,6 +8,5 @@ using Test
 
     rep = JET.report_package(QuantumSymbolics, target_modules=[QuantumSymbolics])
     @show rep
-    @test_broken length(JET.get_reports(rep)) == 0
-    @test length(JET.get_reports(rep)) <= 6
+    @test length(JET.get_reports(rep)) == 0
 end


### PR DESCRIPTION
Resolves #67.

This is a focused bounty submission for the $200 concrete struct field typing task.

Summary:
- Adds concrete or parameterized field types across the core symbolic expression nodes and selected extension helpers.
- Keeps flexible containers where needed with explicit `Any` element types, rather than leaving field declarations untyped.
- Updates symbolic `maketerm` methods to accept parameterized concrete node types.
- Adds `general/field_type_tests.jl`, which loads all test-environment extensions and asserts package-owned struct fields are not left as `Any`, except the generated metadata field.
- Tightens the JET test expectation now that the local report is clean.

Validation run locally on Julia 1.10.10:
- `Pkg.test(; test_args=["general/field_type_tests"])` passed 12/12.
- `Pkg.test(; test_args=["general"])` passed 456 tests with the repo's existing 2 broken tests.
- `Pkg.test(; test_args=["jet"])` passed, with JET reporting `No errors detected`.
- `git diff --check` passed.

I saw the issue body still lists the bounty as claimed by `no one` and the issue has no linked branches/PRs. If there is an active private claim that should take precedence, happy to defer to the maintainer's call.