### PR TITLE
Parameterize and concretely type all struct fields in symbolic types

### DIFF
--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -87,7 +87,8 @@ macro withmetadata(strct)
     if @capture(ex, (struct T_{params__} fields__ end) | (struct T_{params__} <: A_ fields__ end))
         struct_name = namify(T)
         args = (namify(i) for i in fields if !MacroTools.isexpr(i, String, :string))
-        constructor = :($struct_name{S}($(args...)) where S = new{S}($((args..., :(Metadata()))...)))
+        where_params = [namify(p) for p in params]
+        constructor = :($struct_name{$(where_params...)}($(args...)) where {$(params...)} = new{$(where_params...)}($((args..., :(Metadata()))...)))
     elseif @capture(ex, struct T_ fields__ end)
         struct_name = namify(T)
         args = (namify(i) for i in fields if !MacroTools.isexpr(i, String, :string))
@@ -144,9 +145,9 @@ Base.isequal(::Symbolic{Complex}, ::SymQObj) = false
 const SymScalar = Symbolic{Complex}
 
 """Symbolic scaled scalar expression: `coeff * obj` where obj is a `Symbolic{Complex}`."""
-struct SScaledComplex <: Symbolic{Complex}
-    coeff
-    obj
+struct SScaledComplex{C,O} <: Symbolic{Complex}
+    coeff::C
+    obj::O
 end
 isexpr(::SScaledComplex) = true
 iscall(::SScaledComplex) = true
@@ -161,8 +162,8 @@ Base.hash(x::SScaledComplex, h::UInt) = hash((head(x), x.coeff, x.obj), h)
 Base.isequal(x::SScaledComplex, y::SScaledComplex) = isequal(x.coeff, y.coeff) && isequal(x.obj, y.obj)
 
 """Symbolic sum of scalar expressions."""
-struct SAddComplex <: Symbolic{Complex}
-    terms
+struct SAddComplex{T} <: Symbolic{Complex}
+    terms::T
 end
 isexpr(::SAddComplex) = true
 iscall(::SAddComplex) = true
@@ -177,8 +178,8 @@ Base.hash(x::SAddComplex, h::UInt) = hash((:+, Set(x.terms)), h)
 Base.isequal(x::SAddComplex, y::SAddComplex) = Set(x.terms) == Set(y.terms)
 
 """Symbolic product of scalar expressions."""
-struct SMulComplex <: Symbolic{Complex}
-    terms
+struct SMulComplex{T} <: Symbolic{Complex}
+    terms::T
 end
 isexpr(::SMulComplex) = true
 iscall(::SMulComplex) = true

--- a/src/QSymbolicsBase/basic_ops_homogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_homogeneous.jl
@@ -19,9 +19,9 @@ julia> 2*A
 2A
 ```
 """
-@withmetadata struct SScaled{T<:QObj} <: Symbolic{T}
-    coeff
-    obj
+@withmetadata struct SScaled{T<:QObj, C, O} <: Symbolic{T}
+    coeff::C
+    obj::O
 end
 isexpr(::SScaled) = true
 iscall(::SScaled) = true
@@ -104,10 +104,10 @@ julia> k₁ + k₂
 |k₁⟩+|k₂⟩
 ```
 """
-@withmetadata struct SAdd{T<:QObj} <: Symbolic{T}
-    dict
-    _set_precomputed
-    _arguments_precomputed
+@withmetadata struct SAdd{T<:QObj, D, S, A} <: Symbolic{T}
+    dict::D
+    _set_precomputed::S
+    _arguments_precomputed::A
 end
 function SAdd{S}(d) where S
     isempty(d) && return SZero{S}()
@@ -155,8 +155,8 @@ julia> A*B
 AB
 ```
 """
-@withmetadata struct SMulOperator <: Symbolic{AbstractOperator}
-    terms
+@withmetadata struct SMulOperator{T} <: Symbolic{AbstractOperator}
+    terms::T
 end
 isexpr(::SMulOperator) = true
 iscall(::SMulOperator) = true
@@ -199,8 +199,8 @@ julia> A ⊗ B
 A⊗B
 ```
 """
-@withmetadata struct STensor{T<:QObj} <: Symbolic{T}
-    terms
+@withmetadata struct STensor{T<:QObj, Tr} <: Symbolic{T}
+    terms::Tr
 end
 isexpr(::STensor) = true
 iscall(::STensor) = true

--- a/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
@@ -11,9 +11,9 @@ julia> A*k
 A|k⟩
 ```
 """
-@withmetadata struct SApplyKet <: Symbolic{AbstractKet}
-    op
-    ket
+@withmetadata struct SApplyKet{O, K} <: Symbolic{AbstractKet}
+    op::O
+    ket::K
 end
 isexpr(::SApplyKet) = true
 iscall(::SApplyKet) = true
@@ -47,9 +47,9 @@ julia> b*A
 ⟨b|A
 ```
 """
-@withmetadata struct SApplyBra <: Symbolic{AbstractBra}
-    bra
-    op
+@withmetadata struct SApplyBra{B, O} <: Symbolic{AbstractBra}
+    bra::B
+    op::O
 end
 isexpr(::SApplyBra) = true
 iscall(::SApplyBra) = true
@@ -83,9 +83,9 @@ julia> b*k
 ⟨b||k⟩
 ```
 """
-@withmetadata struct SBraKet <: Symbolic{Complex}
-    bra
-    ket
+@withmetadata struct SBraKet{B, K} <: Symbolic{Complex}
+    bra::B
+    ket::K
 end
 isexpr(::SBraKet) = true
 iscall(::SBraKet) = true
@@ -118,9 +118,9 @@ julia> k*b
 |k⟩⟨b|
 ```
 """
-@withmetadata struct SOuterKetBra <: Symbolic{AbstractOperator}
-    ket
-    bra
+@withmetadata struct SOuterKetBra{K, B} <: Symbolic{AbstractOperator}
+    ket::K
+    bra::B
 end
 isexpr(::SOuterKetBra) = true
 iscall(::SOuterKetBra) = true

--- a/src/QSymbolicsBase/basic_superops.jl
+++ b/src/QSymbolicsBase/basic_superops.jl
@@ -16,8 +16,8 @@ julia> K*ρ
 A₁ρA₁†+A₂ρA₂†+A₃ρA₃†
 ```
 """
-@withmetadata struct KrausRepr <: Symbolic{AbstractSuperOperator}
-    krausops
+@withmetadata struct KrausRepr{K} <: Symbolic{AbstractSuperOperator}
+    krausops::K
 end
 isexpr(::KrausRepr) = true
 iscall(::KrausRepr) = true
@@ -46,9 +46,9 @@ julia> S*A
 S[A]
 ```
 """
-@withmetadata struct SSuperOpApply <: Symbolic{AbstractOperator}
-    sop
-    op
+@withmetadata struct SSuperOpApply{S, O} <: Symbolic{AbstractOperator}
+    sop::S
+    op::O
 end
 isexpr(::SSuperOpApply) = true
 iscall(::SSuperOpApply) = true

--- a/src/QSymbolicsBase/linalg.jl
+++ b/src/QSymbolicsBase/linalg.jl
@@ -20,9 +20,9 @@ julia> commutator(A, A)
 𝟎
 ```
 """
-@withmetadata struct SCommutator <: Symbolic{AbstractOperator}
-    op1
-    op2
+@withmetadata struct SCommutator{O1, O2} <: Symbolic{AbstractOperator}
+    op1::O1
+    op2::O2
 end
 isexpr(::SCommutator) = true
 iscall(::SCommutator) = true
@@ -54,9 +54,9 @@ julia> anticommutator(A, B)
 {A,B}
 ```
 """
-@withmetadata struct SAnticommutator <: Symbolic{AbstractOperator}
-    op1
-    op2
+@withmetadata struct SAnticommutator{O1, O2} <: Symbolic{AbstractOperator}
+    op1::O1
+    op2::O2
 end
 isexpr(::SAnticommutator) = true
 iscall(::SAnticommutator) = true
@@ -91,8 +91,8 @@ julia> conj(k)
 |k⟩ˣ
 ```
 """
-@withmetadata struct SConjugate{T<:QObj} <: Symbolic{T}
-    obj
+@withmetadata struct SConjugate{T<:QObj, O} <: Symbolic{T}
+    obj::O
 end
 isexpr(::SConjugate) = true
 iscall(::SConjugate) = true
@@ -131,8 +131,8 @@ Operator(dim=2x2)
  -0.5+0.0im   0.5+0.0im
 ```
 """
-@withmetadata struct SProjector <: Symbolic{AbstractOperator}
-    ket::Symbolic{AbstractKet} # TODO parameterize
+@withmetadata struct SProjector{K} <: Symbolic{AbstractOperator}
+    ket::K
 end
 isexpr(::SProjector) = true
 iscall(::SProjector) = true
@@ -170,8 +170,8 @@ julia> transpose(k)
 |k⟩ᵀ
 ```
 """
-@withmetadata struct STranspose{T<:QObj} <: Symbolic{T}
-    obj
+@withmetadata struct STranspose{T<:QObj, O} <: Symbolic{T}
+    obj::O
 end
 isexpr(::STranspose) = true
 iscall(::STranspose) = true
@@ -222,8 +222,8 @@ julia> dagger(U)
 U⁻¹
 ```
 """
-@withmetadata struct SDagger{T<:QObj} <: Symbolic{T}
-    obj
+@withmetadata struct SDagger{T<:QObj, O} <: Symbolic{T}
+    obj::O
 end
 isexpr(::SDagger) = true
 iscall(::SDagger) = true
@@ -286,8 +286,8 @@ julia> tr(k*b)
 ⟨b||k⟩
 ```
 """
-@withmetadata struct STrace <: Symbolic{Complex}
-    op::Symbolic{AbstractOperator}
+@withmetadata struct STrace{O} <: Symbolic{Complex}
+    op::O
 end
 isexpr(::STrace) = true
 iscall(::STrace) = true
@@ -349,8 +349,8 @@ julia> ptrace(mixed_state, 2)
 (tr(B))|k⟩⟨b|+(⟨b||k⟩)A
 ```
 """
-@withmetadata struct SPartialTrace <: Symbolic{AbstractOperator}
-    obj
+@withmetadata struct SPartialTrace{O} <: Symbolic{AbstractOperator}
+    obj::O
     sys::Int
 end
 isexpr(::SPartialTrace) = true
@@ -447,8 +447,8 @@ julia> inv(A)*A
 𝕀
 ```
 """
-@withmetadata struct SInvOperator <: Symbolic{AbstractOperator}
-    op::Symbolic{AbstractOperator}
+@withmetadata struct SInvOperator{O} <: Symbolic{AbstractOperator}
+    op::O
 end
 isexpr(::SInvOperator) = true
 iscall(::SInvOperator) = true
@@ -477,8 +477,8 @@ julia> exp(A)
 exp(A)
 ```
 """
-@withmetadata struct SExpOperator <: Symbolic{AbstractOperator}
-    op::Symbolic{AbstractOperator}
+@withmetadata struct SExpOperator{O} <: Symbolic{AbstractOperator}
+    op::O
 end
 isexpr(::SExpOperator) = true
 iscall(::SExpOperator) = true
@@ -508,8 +508,8 @@ julia> vec(A+B)
 |A⟩⟩+|B⟩⟩
 ```
 """
-@withmetadata struct SVec <: Symbolic{AbstractKet}
-    op::Symbolic{AbstractOperator}
+@withmetadata struct SVec{O} <: Symbolic{AbstractKet}
+    op::O
 end
 isexpr(::SVec) = true
 iscall(::SVec) = true

--- a/src/QSymbolicsBase/predefined.jl
+++ b/src/QSymbolicsBase/predefined.jl
@@ -7,33 +7,33 @@ isexpr(::SpecialKet) = false
 basis(x::SpecialKet) = x.basis
 Base.show(io::IO, x::SpecialKet) = print(io, "|$(symbollabel(x))⟩")
 
-@withmetadata struct XBasisState <: SpecialKet
+@withmetadata struct XBasisState{B} <: SpecialKet
     idx::Int
-    basis::Basis
+    basis::B
 end
 symbollabel(x::XBasisState) = "X$(num_to_sub(x.idx))"
 
-@withmetadata struct YBasisState <: SpecialKet
+@withmetadata struct YBasisState{B} <: SpecialKet
     idx::Int
-    basis::Basis
+    basis::B
 end
 symbollabel(x::YBasisState) = "Y$(num_to_sub(x.idx))"
 
-@withmetadata struct ZBasisState <: SpecialKet
+@withmetadata struct ZBasisState{B} <: SpecialKet
     idx::Int
-    basis::Basis
+    basis::B
 end
 symbollabel(x::ZBasisState) = "Z$(num_to_sub(x.idx))"
 
-@withmetadata struct MomentumEigenState <: SpecialKet
-    p::Number # TODO parameterize
-    basis::Basis
+@withmetadata struct MomentumEigenState{P, B} <: SpecialKet
+    p::P
+    basis::B
 end
 symbollabel(x::MomentumEigenState) = "δₚ($(x.p))"
 
-@withmetadata struct PositionEigenState <: SpecialKet
-    x::Float64 # TODO parameterize
-    basis::Basis
+@withmetadata struct PositionEigenState{X, B} <: SpecialKet
+    x::X
+    basis::B
 end
 symbollabel(x::PositionEigenState) = "δₓ($(x.x))"
 
@@ -66,10 +66,10 @@ basis(::AbstractTwoQubitGate) = qubit_basis⊗qubit_basis
 Base.show(io::IO, x::AbstractSingleQubitOp) = print(io, "$(symbollabel(x))")
 Base.show(io::IO, x::AbstractTwoQubitOp) = print(io, "$(symbollabel(x))")
 
-@withmetadata struct OperatorEmbedding <: Symbolic{AbstractOperator}
-    gate::Symbolic{AbstractOperator} # TODO parameterize
-    indices::Vector{Int}
-    basis::Basis
+@withmetadata struct OperatorEmbedding{G, I, B} <: Symbolic{AbstractOperator}
+    gate::G
+    indices::I
+    basis::B
 end
 isexpr(::OperatorEmbedding) = true
 
@@ -179,8 +179,8 @@ julia> express(MixedState(X1⊗X2), CliffordRepr())
 + _Z
 ```
 """
-@withmetadata struct MixedState <: Symbolic{AbstractOperator}
-    basis::Basis # From QuantumOpticsBase # TODO make QuantumInterface
+@withmetadata struct MixedState{B} <: Symbolic{AbstractOperator}
+    basis::B
 end
 MixedState(x::Symbolic{AbstractKet}) = MixedState(basis(x))
 MixedState(x::Symbolic{AbstractOperator}) = MixedState(basis(x))
@@ -199,8 +199,8 @@ Operator(dim=2x2)
   basis: Spin(1/2)sparse([1, 2], [1, 2], ComplexF64[1.0 + 0.0im, 1.0 + 0.0im], 2, 2)
 ```
 """
-@withmetadata struct IdentityOp <: Symbolic{AbstractOperator}
-    basis::Basis # From QuantumOpticsBase # TODO make QuantumInterface
+@withmetadata struct IdentityOp{B} <: Symbolic{AbstractOperator}
+    basis::B
 end
 IdentityOp(x::Symbolic{AbstractKet}) = IdentityOp(basis(x))
 IdentityOp(x::Symbolic{AbstractOperator}) = IdentityOp(basis(x))

--- a/src/QSymbolicsBase/predefined_CPTP.jl
+++ b/src/QSymbolicsBase/predefined_CPTP.jl
@@ -10,9 +10,9 @@ basis(x::NoiseCPTP) = x.basis
 Attenuation CPTP map, defined by the beam splitter rotation parameter `theta`
 and thermal noise parameter `noise`.
 """
-@withmetadata struct AttenuatorCPTP <: NoiseCPTP
-    theta::Real
-    noise::Real
+@withmetadata struct AttenuatorCPTP{T, N} <: NoiseCPTP
+    theta::T
+    noise::N
 end
 basis(x::AttenuatorCPTP) = inf_fock_basis
 symbollabel(x::AttenuatorCPTP) = "𝒜𝓉𝓉"
@@ -23,9 +23,9 @@ symbollabel(x::AttenuatorCPTP) = "𝒜𝓉𝓉"
 Amplification CPTP map, defined by the squeezing amplitude parameter `r`
 and thermal noise parameter `noise`.
 """
-@withmetadata struct AmplifierCPTP <: NoiseCPTP
-    r::Real
-    noise::Real
+@withmetadata struct AmplifierCPTP{R, N} <: NoiseCPTP
+    r::R
+    noise::N
 end
 basis(x::AmplifierCPTP) = inf_fock_basis
 symbollabel(x::AmplifierCPTP) = "𝒜𝓂𝓅"
@@ -39,32 +39,32 @@ Operator(dim=2x2)
  0.5+0.0im  0.0+0.0im
  0.0+0.0im  0.5+0.0im
 ```"""
-@withmetadata struct PauliNoiseCPTP <: NoiseCPTP
-    px
-    py
-    pz
+@withmetadata struct PauliNoiseCPTP{X, Y, Z} <: NoiseCPTP
+    px::X
+    py::Y
+    pz::Z
 end
 basis(x::PauliNoiseCPTP) = SpinBasis(1//2)
 symbollabel(x::PauliNoiseCPTP) = "𝒫"
 
 """Single-qubit dephasing CPTP map"""
-@withmetadata struct DephasingCPTP <: NoiseCPTP
-    p
+@withmetadata struct DephasingCPTP{P} <: NoiseCPTP
+    p::P
 end
 basis(x::DephasingCPTP) = SpinBasis(1//2)
 symbollabel(x::DephasingCPTP) = "𝒟𝓅𝒽"
 
 """Single-qubit depolarization CPTP map"""
-@withmetadata struct DepolarizationCPTP <: NoiseCPTP
-    p
-    basis::Basis
+@withmetadata struct DepolarizationCPTP{P, B} <: NoiseCPTP
+    p::P
+    basis::B
 end
 symbollabel(x::DepolarizationCPTP) = "𝒟ℯ𝓅ℴ𝓁"
 
 """A unitary gate followed by a CPTP map"""
-@withmetadata struct GateCPTP <: NoiseCPTP
-    gate::Symbolic{AbstractOperator}
-    cptp::NoiseCPTP
+@withmetadata struct GateCPTP{G, C} <: NoiseCPTP
+    gate::G
+    cptp::C
 end
 basis(x::GateCPTP) = basis(x.cptp)
 function Base.show(io::IO, x::GateCPTP)

--- a/src/QSymbolicsBase/predefined_fock.jl
+++ b/src/QSymbolicsBase/predefined_fock.jl
@@ -16,20 +16,20 @@ end
 symbollabel(x::FockState) = "$(x.idx)"
 
 """Coherent state in defined Fock basis."""
-@withmetadata struct CoherentState <: AbstractSingleBosonState
-    alpha::Number # TODO parameterize
+@withmetadata struct CoherentState{A} <: AbstractSingleBosonState
+    alpha::A
 end
 symbollabel(x::CoherentState) = "$(x.alpha)"
 
 """Squeezed vacuum state in defined Fock basis."""
-@withmetadata struct SqueezedState <: AbstractSingleBosonState
-    z::Number
+@withmetadata struct SqueezedState{Z} <: AbstractSingleBosonState
+    z::Z
 end
 symbollabel(x::SqueezedState) = "0,$(x.z)"
 
 """Two-mode squeezed vacuum state, or EPR state, in defined Fock basis."""
-@withmetadata struct TwoSqueezedState <: AbstractTwoBosonState
-    z::Number
+@withmetadata struct TwoSqueezedState{Z} <: AbstractTwoBosonState
+    z::Z
 end
 symbollabel(x::TwoSqueezedState) = "0,$(x.z)"
 
@@ -112,8 +112,8 @@ julia> qsimplify(phase*c, rewriter=qsimplify_fock)
 |1.2246467991473532e-16 - 1.0im⟩
 ```
 """
-@withmetadata struct PhaseShiftOp <: AbstractSingleBosonGate
-    phase::Number
+@withmetadata struct PhaseShiftOp{P} <: AbstractSingleBosonGate
+    phase::P
 end
 symbollabel(x::PhaseShiftOp) = "U($(x.phase))"
 
@@ -130,8 +130,8 @@ julia> qsimplify(displace*f, rewriter=qsimplify_fock)
 |im⟩
 ```
 """
-@withmetadata struct DisplaceOp <: AbstractSingleBosonGate
-    alpha::Number
+@withmetadata struct DisplaceOp{A} <: AbstractSingleBosonGate
+    alpha::A
 end
 symbollabel(x::DisplaceOp) = "D($(x.alpha))"
 
@@ -153,25 +153,25 @@ julia> qsimplify(S*vac, rewriter=qsimplify_fock)
 |0,π⟩
 ```
 """
-@withmetadata struct SqueezeOp <: AbstractSingleBosonGate
-    z::Number
+@withmetadata struct SqueezeOp{Z} <: AbstractSingleBosonGate
+    z::Z
 end
 symbollabel(x::SqueezeOp) = "S($(x.z))"
 
 """Thermal bosonic state in defined Fock basis."""
-@withmetadata struct BosonicThermalState <: AbstractSingleBosonOp
-    photons::Number
+@withmetadata struct BosonicThermalState{P} <: AbstractSingleBosonOp
+    photons::P
 end
 symbollabel(x::BosonicThermalState) = "ρₜₕ($(x.photons))"
 
 """Two-mode squeezing operator in defined Fock basis."""
-@withmetadata struct TwoSqueezeOp <: AbstractTwoBosonGate
-    z::Number
+@withmetadata struct TwoSqueezeOp{Z} <: AbstractTwoBosonGate
+    z::Z
 end
 symbollabel(x::TwoSqueezeOp) = "S₂($(x.z))"
 
 """Two-mode beamsplitter operator in defined Fock basis."""
-@withmetadata struct BeamSplitterOp <: AbstractTwoBosonGate
-    transmit::Number
+@withmetadata struct BeamSplitterOp{T} <: AbstractTwoBosonGate
+    transmit::T
 end
 symbollabel(x::BeamSplitterOp) = "B($(x.transmit))"


### PR DESCRIPTION
Fixes #67 by parameterizing and concretely typing struct fields across the package.