### PR TITLE
Skip documentation and changelog checks for Dependabot

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,6 +38,7 @@ steps:
           codecov: true
 
   - label: "Docs"
+    branches: "!dependabot/*"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"

--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   # Enforces the update of a changelog file on every pull request 
   changelog:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - uses: dangoslen/changelog-enforcer@v3

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -30,6 +30,18 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
+      - name: Disable workspace directive for downgrade run
+        run: |
+          julia --color=yes -e '
+            using TOML
+            project = TOML.parsefile("Project.toml")
+            if haskey(project, "workspace")
+              delete!(project, "workspace")
+              open("Project.toml", "w") do io
+                TOML.print(io, project)
+              end
+            end
+          '
       - uses: julia-actions/julia-downgrade-compat@v2
         with:
           skip: Pkg,TOML,InteractiveUtils,Random,LinearAlgebra


### PR DESCRIPTION
## Summary

- exclude Dependabot branches from the Buildkite documentation step
- skip GitHub changelog enforcement for Dependabot pull requests
- retain both checks for human-authored pull requests
- temporarily remove the root `[workspace]` directive only inside the Julia 1.12 downgrade job, keeping downgrade coverage focused on package dependencies instead of minimizing docs and benchmark environments

## Failure evidence

The previous downgrade run minimized workspace-only dependencies and selected OpenSSH_jll 9.9.1, while the resolved OpenSSL_jll 3.5.4 requires OpenSSH_jll 10.x. Pkg therefore failed before any tests ran.

## Validation

- exact `julia-downgrade-compat@fab1def` reproduction after the ephemeral workspace suppression passes all general tests: 438 passed, 2 expected broken
- docs and benchmark workspace declarations remain unchanged in the repository
- `gh act -n --validate`
- workflow YAML parse and `git diff --check`