### PR TITLE
All struct fields are concretely typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # News
 
+## v0.4.18 - 2026-08-17
+
+- All the fields of all the symbolic structs are now concretely typed, in most cases through newly added type parameters (e.g. `SKet{B<:Basis}`, `SScaled{T<:QObj,C<:SymCoeff,O<:Symbolic{T}}`, `SProjector{K<:Symbolic{AbstractKet}}`, `CoherentState{T<:Number}`), in preparation for a future move to sum types. The constructors keep their previous signatures and infer the new parameters, but code that spells out the full type of a symbolic object has to be updated.
+- `isequal` and `hash` of symbolic quantum objects ignore the type parameters that merely record the types of the fields, so e.g. `CoherentState(1)` and `CoherentState(1.0)` are still equal.
+- Fix `isequal` considering two products (or tensor products) of different lengths equal, e.g. `A*B` and `A*B*C`.
+- Fix a `MethodError` when multiplying an operator by the inverse of a different operator.
+- A product of operators no longer splices the arguments of other `*`-headed expressions (an outer product or a superoperator application) into the `SMulOperator` it builds, so its terms are always operators. The printed and expressed results are unchanged.
+
 ## v0.4.17 - 2026-08-06
 
 - **(fix)** Complete Clifford observable lowering for symbolic Pauli tensors, identities, and native `PauliOperator`s.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumSymbolics"
 uuid = "efa7fd63-0460-4890-beb7-be1bbdfbaeae"
 authors = ["QuantumSymbolics.jl contributors"]
-version = "0.4.17"
+version = "0.4.18"
 
 [workspace]
 projects = ["benchmark", "docs"]

--- a/ext/QuantumCliffordExt/QuantumCliffordExt.jl
+++ b/ext/QuantumCliffordExt/QuantumCliffordExt.jl
@@ -67,9 +67,9 @@ express_nolookup(op::SScaledOperator, r::CliffordRepr, u::UseAsObservable) = arg
 express_nolookup(x::SMulOperator,     r::CliffordRepr, u::UseAsObservable) = (*)((express(t,r,u) for t in arguments(x))...)
 express_nolookup(op, ::CliffordRepr, ::UseAsObservable) = error("Can not convert $(op) into a `PauliOperator`, which is the only observable that can be computed for QuantumClifford objects. Consider defining `express_nolookup(op, ::CliffordRepr, ::UseAsObservable)::PauliOperator` for this object.")
 
-struct QCRandomSampler # TODO specify types
-    operators # union of QCRandomSampler and MixedDestabilizer
-    weights
+struct QCRandomSampler{O<:AbstractVector,W<:AbstractVector}
+    operators::O # each entry is a `QCRandomSampler` or a `MixedDestabilizer`
+    weights::W
 end
 function express_nolookup(x::SAddOperator, repr::CliffordRepr)
     weights = collect(values(x.dict))
@@ -91,8 +91,8 @@ function express_nolookup(x::MixedState, ::CliffordRepr)
 end
 express_nolookup(x::SProjector, repr::CliffordRepr) = express_nolookup(x.ket, repr)
 
-struct QCGateSequence <: QuantumClifford.AbstractSymbolicOperator
-    gates # TODO constructor that flattens nested QCGateSequence
+struct QCGateSequence{G<:AbstractVector} <: QuantumClifford.AbstractSymbolicOperator
+    gates::G # TODO constructor that flattens nested QCGateSequence
 end
 
 function QuantumClifford.apply!(

--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -121,7 +121,7 @@ function Base.isequal(x::X,y::Y) where {X<:SymQObj, Y<:SymQObj}
         if isexpr(x)
             if operation(x)==operation(y)
                 ax,ay = arguments(x),arguments(y)
-                (operation(x) === +) ? x._set_precomputed == y._set_precomputed : all(zip(ax,ay)) do xy isequal(xy...) end
+                (operation(x) === +) ? x._set_precomputed == y._set_precomputed : (length(ax)==length(ay) && all(zip(ax,ay)) do xy isequal(xy...) end)
             else
                 false
             end

--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -180,10 +180,16 @@ Base.isequal(::Symbolic{Complex}, ::SymQObj) = false
 
 const SymScalar = Symbolic{Complex}
 
+"""The scalar coefficients that are allowed to appear in symbolic quantum expressions.
+
+Either a plain number, a `SymbolicUtils`/`Symbolics` scalar expression, or one of the scalar
+symbolic objects of this library (e.g. `SBraKet` or `STrace`)."""
+const SymCoeff = Union{Number,SymbolicUtils.BasicSymbolic,SymScalar}
+
 """Symbolic scaled scalar expression: `coeff * obj` where obj is a `Symbolic{Complex}`."""
-struct SScaledComplex <: Symbolic{Complex}
-    coeff
-    obj
+struct SScaledComplex{C<:SymCoeff,O<:SymScalar} <: Symbolic{Complex}
+    coeff::C
+    obj::O
 end
 isexpr(::SScaledComplex) = true
 iscall(::SScaledComplex) = true
@@ -192,14 +198,14 @@ operation(::SScaledComplex) = *
 head(::SScaledComplex) = :*
 children(x::SScaledComplex) = [:*, x.coeff, x.obj]
 metadata(::SScaledComplex) = nothing
-maketerm(::Type{SScaledComplex}, f, a, m) = f(a...)
+maketerm(::Type{<:SScaledComplex}, f, a, m) = f(a...)
 Base.show(io::IO, x::SScaledComplex) = print(io, "($(x.coeff))$(x.obj)")
 Base.hash(x::SScaledComplex, h::UInt) = hash((head(x), x.coeff, x.obj), h)
 Base.isequal(x::SScaledComplex, y::SScaledComplex) = isequal(x.coeff, y.coeff) && isequal(x.obj, y.obj)
 
 """Symbolic sum of scalar expressions."""
 struct SAddComplex <: Symbolic{Complex}
-    terms
+    terms::Vector{SymCoeff}
 end
 isexpr(::SAddComplex) = true
 iscall(::SAddComplex) = true
@@ -215,7 +221,7 @@ Base.isequal(x::SAddComplex, y::SAddComplex) = Set(x.terms) == Set(y.terms)
 
 """Symbolic product of scalar expressions."""
 struct SMulComplex <: Symbolic{Complex}
-    terms
+    terms::Vector{SymCoeff}
 end
 isexpr(::SMulComplex) = true
 iscall(::SMulComplex) = true
@@ -243,7 +249,8 @@ Base.:(-)(x::SymScalar, y::SymScalar) = x + (-y)
 Base.iszero(::SymScalar) = false
 Base.isone(::SymScalar) = false
 
-# Allow Symbolic{Complex} as coefficient in quantum SScaled (handled by the Union dispatch in basic_ops_homogeneous.jl)
+# `Symbolic{Complex}` is allowed as a coefficient in the quantum `SScaled` as well,
+# through the `SymCoeff` union used in basic_ops_homogeneous.jl
 
 # TODO check that this does not cause incredibly bad runtime performance
 # use a macro to provide specializations if that is indeed the case

--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -75,7 +75,7 @@ end
 # Metadata cache helpers
 ##
 
-const CacheType = Dict{Tuple{<:AbstractRepresentation,<:AbstractUse},Any}
+const CacheType = Dict{Tuple{AbstractRepresentation,AbstractUse},Any}
 mutable struct Metadata
     express_cache::CacheType # TODO use more efficient mapping
 end

--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -81,27 +81,49 @@ mutable struct Metadata
 end
 Metadata() = Metadata(CacheType())
 
-"""Decorate a struct definition in order to add a metadata dict which would be storing cached `express` results."""
+"""Decorate a struct definition in order to add a metadata dict which would be storing cached `express` results.
+
+The decorated struct gains a trailing `metadata::Metadata` field and an inner constructor that
+takes only the "real" fields and initializes the metadata itself. Type parameters are preserved,
+so `@withmetadata struct Foo{A,B<:Bar} ... end` gets `Foo{A,B}(fields...)`, plus the parameter
+free `Foo(fields...)` whenever every parameter is spelled out as the type of one of the fields.
+
+The constructor is deliberately an inner one: it keeps Julia from generating the default
+constructors, which would otherwise take the metadata as their last argument and clash with the
+constructors that the users of this macro define for their own structs."""
 macro withmetadata(strct)
     ex = quote $strct end
     if @capture(ex, (struct T_{params__} fields__ end) | (struct T_{params__} <: A_ fields__ end))
         struct_name = namify(T)
-        args = (namify(i) for i in fields if !MacroTools.isexpr(i, String, :string))
-        constructor = :($struct_name{S}($(args...)) where S = new{S}($((args..., :(Metadata()))...)))
-    elseif @capture(ex, struct T_ fields__ end)
+        pnames = map(namify, params) # the bare parameter names, without their `<:` bounds
+        decls = [i for i in fields if !MacroTools.isexpr(i, String, :string)]
+        args = map(namify, decls)
+        constructor = :($struct_name{$(pnames...)}($(args...)) where {$(params...)} = new{$(pnames...)}($(args...), Metadata()))
+        # a parameter given as the whole type of a field can be deduced from the arguments, so
+        # if that is the case for all of them, the parameters need not be spelled out at all
+        fieldof = Dict{Symbol,Symbol}()
+        for d in decls
+            MacroTools.isexpr(d, :(::)) && d.args[2] isa Symbol || continue
+            d.args[2] in pnames && get!(fieldof, d.args[2], d.args[1])
+        end
+        outer = all(p->haskey(fieldof,p), pnames) ?
+            :($struct_name($(args...)) = $struct_name{$((:(typeof($(fieldof[p]))) for p in pnames)...)}($(args...))) :
+            nothing
+    else
+        @capture(ex, struct T_ fields__ end)
         struct_name = namify(T)
-        args = (namify(i) for i in fields if !MacroTools.isexpr(i, String, :string))
-        constructor = :($struct_name($(args...)) = new($((args..., :(Metadata()))...)))
-    else @capture(ex, struct T_ end)
-        struct_name = namify(T)
-        constructor = :($struct_name() = new($:(Metadata())))
+        args = [namify(i) for i in fields if !MacroTools.isexpr(i, String, :string)]
+        constructor = :($struct_name($(args...)) = new($(args...), Metadata()))
+        outer = nothing
     end
     struct_args = strct.args[end].args
     push!(struct_args, constructor, :(metadata::Metadata))
-    esc(quote
+    out = quote
     Base.@__doc__ $strct
-    metadata(x::$struct_name)=x.metadata
-    end)
+    end
+    isnothing(outer) || push!(out.args, outer)
+    push!(out.args, :(metadata(x::$struct_name)=x.metadata))
+    esc(out)
 end
 
 ##

--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -132,14 +132,29 @@ end
 
 const QObj = Union{AbstractBra,AbstractKet,AbstractOperator,AbstractSuperOperator}
 const SymQObj = Symbolic{<:QObj} # TODO Should we use Sym or Symbolic... Sym has a lot of predefined goodies, including metadata support
+
+"""The type of quantum object (`AbstractBra`, `AbstractKet`, `AbstractOperator`, or
+`AbstractSuperOperator`) that a symbolic object stands for."""
+qobjtype(::Symbolic{T}) where {T<:QObj} = T
+qobjtype(::Type{<:Symbolic{T}}) where {T<:QObj} = T
+
+"""Whether two symbolic objects are instances of the same struct standing for the same kind of
+quantum object.
+
+The type parameters that only specify the types of the fields are deliberately ignored, so
+that e.g. `CoherentState(1)` and `CoherentState(1.0)` are still considered to be of the same
+kind (and are `isequal`, as the numbers `1` and `1.0` are)."""
+samekind(::Type{X}, ::Type{Y}) where {X<:SymQObj,Y<:SymQObj} =
+    Base.typename(X) === Base.typename(Y) && qobjtype(X) === qobjtype(Y)
+
 Base.:(-)(x::SymQObj) = (-1)*x
 Base.:(-)(x::SymQObj,y::SymQObj) = x + (-y)
 Base.hash(x::SymQObj, h::UInt) = isexpr(x) ? hash((head(x), arguments(x)), h) :
-hash((typeof(x),symbollabel(x),basis(x)), h)
+hash((Base.typename(typeof(x)),qobjtype(typeof(x)),symbollabel(x),basis(x)), h)
 maketerm(::Type{<:SymQObj}, f, a, m) = f(a...)
 
 function Base.isequal(x::X,y::Y) where {X<:SymQObj, Y<:SymQObj}
-    if X==Y
+    if samekind(X,Y)
         if isexpr(x)
             if operation(x)==operation(y)
                 ax,ay = arguments(x),arguments(y)

--- a/src/QSymbolicsBase/basic_ops_homogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_homogeneous.jl
@@ -121,11 +121,10 @@ operation(x::SAdd) = +
 head(x::SAdd) = :+
 children(x::SAdd) = [:+; x._arguments_precomputed]
 function Base.:(+)(x::Symbolic{T}, xs::Vararg{Symbolic{T}, N}) where {T<:QObj, N}
-    xs = (x, xs...)
-    xs = collect(xs)
-    f = first(xs)
-    nonzero_terms = filter!(x->!iszero(x),xs)
-    isempty(nonzero_terms) ? f : SAdd{T}(countmap_flatten(nonzero_terms, SAdd{T}, SScaled{T}))
+    terms = Symbolic{T}[x, xs...]
+    f = first(terms)
+    nonzero_terms = filter!(x->!iszero(x),terms)
+    isempty(nonzero_terms) ? f : SAdd{T}(countmap_flatten(nonzero_terms, SAdd{T}, SScaled{T}, Symbolic{T}))
 end
 basis(x::SAdd) = basis(first(x.dict).first)
 
@@ -165,13 +164,13 @@ operation(x::SMulOperator) = *
 head(x::SMulOperator) = :*
 children(x::SMulOperator) = [:*;x.terms]
 function Base.:(*)(x::Symbolic{AbstractOperator}, xs::Vararg{Symbolic{AbstractOperator}, N}) where {N}
-    xs = (x, xs...)
-    zero_ind = findfirst(x->iszero(x), xs)
+    ops = Symbolic{AbstractOperator}[x, xs...]
+    zero_ind = findfirst(x->iszero(x), ops)
     if isnothing(zero_ind)
-        if any(x->!(samebases(basis(x),basis(first(xs)))),xs)
+        if any(x->!(samebases(basis(x),basis(first(ops)))),ops)
             throw(IncompatibleBases())
         else
-            terms = flattenop(*, collect(xs))
+            terms = flattenop(SMulOperator, ops)
             coeff, cleanterms = prefactorscalings(terms)
             coeff * SMulOperator(cleanterms)
         end
@@ -211,7 +210,7 @@ children(x::STensor) = [:⊗; x.terms]
 function ⊗(xs::Symbolic{T}...) where {T<:QObj}
     zero_ind = findfirst(x->iszero(x), xs)
     if isnothing(zero_ind)
-        terms = flattenop(⊗, collect(xs))
+        terms = flattenop(STensor{T}, Symbolic{T}[xs...])
         coeff, cleanterms = prefactorscalings(terms)
         coeff * STensor{T}(cleanterms)
     else

--- a/src/QSymbolicsBase/basic_ops_homogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_homogeneous.jl
@@ -97,12 +97,8 @@ function Base.show(io::IO, x::SScaledBra)
     end
 end
 
-"""The mapping from the terms of a symbolic sum to their scalar coefficients.
-
-The values are left as `Any` because a coefficient can be a number, a `SymbolicUtils`
-expression, or one of the scalar symbolic objects of this library (see `SymCoeff`), and
-because they are repeatedly accumulated with `+` and `*`."""
-const SAddDict{T} = Dict{Symbolic{T},Any}
+"""The mapping from the terms of a symbolic sum to their scalar coefficients."""
+const SAddDict{T} = Dict{Symbolic{T},SymCoeff}
 
 """Addition of quantum objects (kets, operators, or bras).
 

--- a/src/QSymbolicsBase/basic_ops_homogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_homogeneous.jl
@@ -19,17 +19,19 @@ julia> 2*A
 2A
 ```
 """
-@withmetadata struct SScaled{T<:QObj} <: Symbolic{T}
-    coeff
-    obj
+@withmetadata struct SScaled{T<:QObj,C<:SymCoeff,O<:Symbolic{T}} <: Symbolic{T}
+    coeff::C
+    obj::O
 end
+SScaled{T}(coeff::C, obj::O) where {T<:QObj,C<:SymCoeff,O<:Symbolic{T}} = SScaled{T,C,O}(coeff, obj)
+SScaled(coeff::SymCoeff, obj::Symbolic{T}) where {T<:QObj} = SScaled{T}(coeff, obj)
 isexpr(::SScaled) = true
 iscall(::SScaled) = true
 arguments(x::SScaled) = [x.coeff,x.obj]
 operation(x::SScaled) = *
 head(x::SScaled) = :*
 children(x::SScaled) = [:*,x.coeff,x.obj]
-function Base.:(*)(c::U, x::Symbolic{T}) where {U<:Union{Number, SymbolicUtils.BasicSymbolic, Symbolic{Complex}},T<:QObj}
+function Base.:(*)(c::U, x::Symbolic{T}) where {U<:SymCoeff,T<:QObj}
     if (c isa Number && iszero(c)) || iszero(x)
         SZero{T}()
     elseif _isone(c)
@@ -95,6 +97,13 @@ function Base.show(io::IO, x::SScaledBra)
     end
 end
 
+"""The mapping from the terms of a symbolic sum to their scalar coefficients.
+
+The values are left as `Any` because a coefficient can be a number, a `SymbolicUtils`
+expression, or one of the scalar symbolic objects of this library (see `SymCoeff`), and
+because they are repeatedly accumulated with `+` and `*`."""
+const SAddDict{T} = Dict{Symbolic{T},Any}
+
 """Addition of quantum objects (kets, operators, or bras).
 
 ```jldoctest
@@ -105,14 +114,14 @@ julia> k₁ + k₂
 ```
 """
 @withmetadata struct SAdd{T<:QObj} <: Symbolic{T}
-    dict
-    _set_precomputed
-    _arguments_precomputed
+    dict::SAddDict{T}
+    _set_precomputed::Set{Symbolic{T}}
+    _arguments_precomputed::Vector{Symbolic{T}}
 end
-function SAdd{S}(d) where S
-    isempty(d) && return SZero{S}()
-    terms = [c*obj for (obj,c) in d]
-    length(d)==1 ? first(terms) : SAdd{S}(d,Set(terms),terms)
+function SAdd{T}(d) where {T<:QObj}
+    isempty(d) && return SZero{T}()
+    terms = Symbolic{T}[c*obj for (obj,c) in d]
+    length(d)==1 ? first(terms) : SAdd{T}(d,Set(terms),terms)
 end
 isexpr(::SAdd) = true
 iscall(::SAdd) = true
@@ -155,7 +164,7 @@ AB
 ```
 """
 @withmetadata struct SMulOperator <: Symbolic{AbstractOperator}
-    terms
+    terms::Vector{Symbolic{AbstractOperator}}
 end
 isexpr(::SMulOperator) = true
 iscall(::SMulOperator) = true
@@ -199,7 +208,7 @@ A⊗B
 ```
 """
 @withmetadata struct STensor{T<:QObj} <: Symbolic{T}
-    terms
+    terms::Vector{Symbolic{T}}
 end
 isexpr(::STensor) = true
 iscall(::STensor) = true

--- a/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
@@ -11,9 +11,9 @@ julia> A*k
 A|k⟩
 ```
 """
-@withmetadata struct SApplyKet <: Symbolic{AbstractKet}
-    op
-    ket
+@withmetadata struct SApplyKet{O<:Symbolic{AbstractOperator},K<:Symbolic{AbstractKet}} <: Symbolic{AbstractKet}
+    op::O
+    ket::K
 end
 isexpr(::SApplyKet) = true
 iscall(::SApplyKet) = true
@@ -47,9 +47,9 @@ julia> b*A
 ⟨b|A
 ```
 """
-@withmetadata struct SApplyBra <: Symbolic{AbstractBra}
-    bra
-    op
+@withmetadata struct SApplyBra{B<:Symbolic{AbstractBra},O<:Symbolic{AbstractOperator}} <: Symbolic{AbstractBra}
+    bra::B
+    op::O
 end
 isexpr(::SApplyBra) = true
 iscall(::SApplyBra) = true
@@ -83,9 +83,9 @@ julia> b*k
 ⟨b||k⟩
 ```
 """
-@withmetadata struct SBraKet <: Symbolic{Complex}
-    bra
-    ket
+@withmetadata struct SBraKet{B<:Symbolic{AbstractBra},K<:Symbolic{AbstractKet}} <: Symbolic{Complex}
+    bra::B
+    ket::K
 end
 isexpr(::SBraKet) = true
 iscall(::SBraKet) = true
@@ -106,7 +106,7 @@ Base.:(*)(b::Symbolic{AbstractBra}, k::SZeroKet) = 0
 Base.:(*)(b::SZeroBra, k::SZeroKet) = 0
 Base.show(io::IO, x::SBraKet) = begin print(io,x.bra); print(io,x.ket) end
 Base.hash(x::SBraKet, h::UInt) = hash((head(x), arguments(x)), h)
-maketerm(::Type{SBraKet}, f, a, m) = f(a...)
+maketerm(::Type{<:SBraKet}, f, a, m) = f(a...)
 Base.isequal(x::SBraKet, y::SBraKet) = isequal(x.bra, y.bra) && isequal(x.ket, y.ket)
 
 """Symbolic outer product of a ket and a bra.
@@ -118,9 +118,9 @@ julia> k*b
 |k⟩⟨b|
 ```
 """
-@withmetadata struct SOuterKetBra <: Symbolic{AbstractOperator}
-    ket
-    bra
+@withmetadata struct SOuterKetBra{K<:Symbolic{AbstractKet},B<:Symbolic{AbstractBra}} <: Symbolic{AbstractOperator}
+    ket::K
+    bra::B
 end
 isexpr(::SOuterKetBra) = true
 iscall(::SOuterKetBra) = true

--- a/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_inhomogeneous.jl
@@ -25,7 +25,7 @@ function Base.:(*)(op::Symbolic{AbstractOperator}, k::Symbolic{AbstractKet})
     if !(samebases(basis(op),basis(k)))
         throw(IncompatibleBases())
     else
-        coeff, cleanterms = prefactorscalings([op k])
+        coeff, cleanterms = prefactorscalings(Symbolic[op, k])
         coeff*SApplyKet(cleanterms...)
     end
 end
@@ -61,7 +61,7 @@ function Base.:(*)(b::Symbolic{AbstractBra}, op::Symbolic{AbstractOperator})
     if !(samebases(basis(b),basis(op)))
         throw(IncompatibleBases())
     else
-        coeff, cleanterms = prefactorscalings([b op])
+        coeff, cleanterms = prefactorscalings(Symbolic[b, op])
         coeff*SApplyBra(cleanterms...)
     end
 end
@@ -97,7 +97,7 @@ function Base.:(*)(b::Symbolic{AbstractBra}, k::Symbolic{AbstractKet})
     if !(samebases(basis(b),basis(k)))
         throw(IncompatibleBases())
     else
-        coeff, cleanterms = prefactorscalings([b k])
+        coeff, cleanterms = prefactorscalings(Symbolic[b, k])
         coeff == 1 ? SBraKet(cleanterms...) : coeff*SBraKet(cleanterms...)
     end
 end
@@ -132,7 +132,7 @@ function Base.:(*)(k::Symbolic{AbstractKet}, b::Symbolic{AbstractBra})
     if !(samebases(basis(k),basis(b)))
         throw(IncompatibleBases())
     else
-        coeff, cleanterms = prefactorscalings([k b])
+        coeff, cleanterms = prefactorscalings(Symbolic[k, b])
         coeff*SOuterKetBra(cleanterms...)
     end
 end

--- a/src/QSymbolicsBase/basic_superops.jl
+++ b/src/QSymbolicsBase/basic_superops.jl
@@ -17,7 +17,7 @@ A₁ρA₁†+A₂ρA₂†+A₃ρA₃†
 ```
 """
 @withmetadata struct KrausRepr <: Symbolic{AbstractSuperOperator}
-    krausops
+    krausops::Vector{Symbolic{AbstractOperator}}
 end
 isexpr(::KrausRepr) = true
 iscall(::KrausRepr) = true
@@ -25,7 +25,7 @@ arguments(x::KrausRepr) = x.krausops
 operation(x::KrausRepr) = kraus
 head(x::KrausRepr) = :kraus
 children(x::KrausRepr) = [:kraus; x.krausops]
-kraus(xs::Symbolic{AbstractOperator}...) = KrausRepr(collect(xs))
+kraus(xs::Symbolic{AbstractOperator}...) = KrausRepr(Symbolic{AbstractOperator}[xs...])
 basis(x::KrausRepr) = basis(first(x.krausops))
 Base.:(*)(sop::KrausRepr, op::Symbolic{AbstractOperator}) = (+)((i*op*dagger(i) for i in sop.krausops)...)
 Base.:(*)(sop::KrausRepr, k::Symbolic{AbstractKet}) = (+)((i*SProjector(k)*dagger(i) for i in sop.krausops)...)
@@ -46,9 +46,9 @@ julia> S*A
 S[A]
 ```
 """
-@withmetadata struct SSuperOpApply <: Symbolic{AbstractOperator}
-    sop
-    op
+@withmetadata struct SSuperOpApply{S<:Symbolic{AbstractSuperOperator},O<:Symbolic{AbstractOperator}} <: Symbolic{AbstractOperator}
+    sop::S
+    op::O
 end
 isexpr(::SSuperOpApply) = true
 iscall(::SSuperOpApply) = true

--- a/src/QSymbolicsBase/linalg.jl
+++ b/src/QSymbolicsBase/linalg.jl
@@ -34,7 +34,7 @@ function commutator(o1::Symbolic{AbstractOperator}, o2::Symbolic{AbstractOperato
     if !(samebases(basis(o1),basis(o2)))
         throw(IncompatibleBases())
     else
-        coeff, cleanterms = prefactorscalings([o1 o2])
+        coeff, cleanterms = prefactorscalings(Symbolic{AbstractOperator}[o1, o2])
         cleanterms[1] === cleanterms[2] ? SZeroOperator() : coeff * SCommutator(cleanterms...)
     end
 end
@@ -68,7 +68,7 @@ function anticommutator(o1::Symbolic{AbstractOperator}, o2::Symbolic{AbstractOpe
     if !(samebases(basis(o1),basis(o2)))
         throw(IncompatibleBases())
     else
-        coeff, cleanterms = prefactorscalings([o1 o2])
+        coeff, cleanterms = prefactorscalings(Symbolic{AbstractOperator}[o1, o2])
         coeff * SAnticommutator(cleanterms...)
     end
 end

--- a/src/QSymbolicsBase/linalg.jl
+++ b/src/QSymbolicsBase/linalg.jl
@@ -458,8 +458,8 @@ head(x::SInvOperator) = :inv
 children(x::SInvOperator) = [:inv, x.op]
 basis(x::SInvOperator) = basis(x.op)
 Base.show(io::IO, x::SInvOperator) = print(io, "$(x.op)⁻¹")
-Base.:(*)(invop::SInvOperator, op::SOperator) = isequal(invop.op, op) ? IdentityOp(basis(op)) : SMulOperator(invop, op)
-Base.:(*)(op::SOperator, invop::SInvOperator) = isequal(op, invop.op) ? IdentityOp(basis(op)) : SMulOperator(op, invop)
+Base.:(*)(invop::SInvOperator, op::SOperator) = isequal(invop.op, op) ? IdentityOp(basis(op)) : SMulOperator(Symbolic{AbstractOperator}[invop, op])
+Base.:(*)(op::SOperator, invop::SInvOperator) = isequal(op, invop.op) ? IdentityOp(basis(op)) : SMulOperator(Symbolic{AbstractOperator}[op, invop])
 """
     inv(x::Symbolic{AbstractOperator})
 

--- a/src/QSymbolicsBase/linalg.jl
+++ b/src/QSymbolicsBase/linalg.jl
@@ -20,9 +20,9 @@ julia> commutator(A, A)
 𝟎
 ```
 """
-@withmetadata struct SCommutator <: Symbolic{AbstractOperator}
-    op1
-    op2
+@withmetadata struct SCommutator{O1<:Symbolic{AbstractOperator},O2<:Symbolic{AbstractOperator}} <: Symbolic{AbstractOperator}
+    op1::O1
+    op2::O2
 end
 isexpr(::SCommutator) = true
 iscall(::SCommutator) = true
@@ -54,9 +54,9 @@ julia> anticommutator(A, B)
 {A,B}
 ```
 """
-@withmetadata struct SAnticommutator <: Symbolic{AbstractOperator}
-    op1
-    op2
+@withmetadata struct SAnticommutator{O1<:Symbolic{AbstractOperator},O2<:Symbolic{AbstractOperator}} <: Symbolic{AbstractOperator}
+    op1::O1
+    op2::O2
 end
 isexpr(::SAnticommutator) = true
 iscall(::SAnticommutator) = true
@@ -91,9 +91,10 @@ julia> conj(k)
 |k⟩ˣ
 ```
 """
-@withmetadata struct SConjugate{T<:QObj} <: Symbolic{T}
-    obj
+@withmetadata struct SConjugate{T<:QObj,O<:Symbolic{T}} <: Symbolic{T}
+    obj::O
 end
+SConjugate{T}(obj::O) where {T<:QObj,O<:Symbolic{T}} = SConjugate{T,O}(obj)
 isexpr(::SConjugate) = true
 iscall(::SConjugate) = true
 arguments(x::SConjugate) = [x.obj]
@@ -131,8 +132,8 @@ Operator(dim=2x2)
  -0.5+0.0im   0.5+0.0im
 ```
 """
-@withmetadata struct SProjector <: Symbolic{AbstractOperator}
-    ket::Symbolic{AbstractKet} # TODO parameterize
+@withmetadata struct SProjector{K<:Symbolic{AbstractKet}} <: Symbolic{AbstractOperator}
+    ket::K
 end
 isexpr(::SProjector) = true
 iscall(::SProjector) = true
@@ -170,9 +171,10 @@ julia> transpose(k)
 |k⟩ᵀ
 ```
 """
-@withmetadata struct STranspose{T<:QObj} <: Symbolic{T}
-    obj
+@withmetadata struct STranspose{T<:QObj,O<:Symbolic{T}} <: Symbolic{T}
+    obj::O
 end
+STranspose{T}(obj::O) where {T<:QObj,O<:Symbolic{T}} = STranspose{T,O}(obj)
 isexpr(::STranspose) = true
 iscall(::STranspose) = true
 arguments(x::STranspose) = [x.obj]
@@ -222,9 +224,10 @@ julia> dagger(U)
 U⁻¹
 ```
 """
-@withmetadata struct SDagger{T<:QObj} <: Symbolic{T}
-    obj
+@withmetadata struct SDagger{T<:QObj,O<:Symbolic} <: Symbolic{T}
+    obj::O
 end
+SDagger{T}(obj::O) where {T<:QObj,O<:Symbolic} = SDagger{T,O}(obj)
 isexpr(::SDagger) = true
 iscall(::SDagger) = true
 arguments(x::SDagger) = [x.obj]
@@ -286,8 +289,8 @@ julia> tr(k*b)
 ⟨b||k⟩
 ```
 """
-@withmetadata struct STrace <: Symbolic{Complex}
-    op::Symbolic{AbstractOperator}
+@withmetadata struct STrace{O<:Symbolic{AbstractOperator}} <: Symbolic{Complex}
+    op::O
 end
 isexpr(::STrace) = true
 iscall(::STrace) = true
@@ -349,8 +352,8 @@ julia> ptrace(mixed_state, 2)
 (tr(B))|k⟩⟨b|+(⟨b||k⟩)A
 ```
 """
-@withmetadata struct SPartialTrace <: Symbolic{AbstractOperator}
-    obj
+@withmetadata struct SPartialTrace{O<:Symbolic{AbstractOperator}} <: Symbolic{AbstractOperator}
+    obj::O
     sys::Int
 end
 isexpr(::SPartialTrace) = true
@@ -385,7 +388,7 @@ function ptrace(x::Symbolic{AbstractOperator}, s)
     end
 end
 function ptrace(x::SAddOperator, s)
-    add_terms = []
+    add_terms = Symbolic{AbstractOperator}[]
     if isa(basis(x), CompositeBasis)
         for i in arguments(x)
             if isexpr(i)
@@ -423,7 +426,6 @@ function ptrace(x::STensorOperator, s)
         ptrace(ex, s)
     else
         terms = arguments(ex)
-        newterms = []
         if any(i -> isa(basis(i), CompositeBasis), terms)
             SPartialTrace(ex, s)
         else
@@ -447,8 +449,8 @@ julia> inv(A)*A
 𝕀
 ```
 """
-@withmetadata struct SInvOperator <: Symbolic{AbstractOperator}
-    op::Symbolic{AbstractOperator}
+@withmetadata struct SInvOperator{O<:Symbolic{AbstractOperator}} <: Symbolic{AbstractOperator}
+    op::O
 end
 isexpr(::SInvOperator) = true
 iscall(::SInvOperator) = true
@@ -477,8 +479,8 @@ julia> exp(A)
 exp(A)
 ```
 """
-@withmetadata struct SExpOperator <: Symbolic{AbstractOperator}
-    op::Symbolic{AbstractOperator}
+@withmetadata struct SExpOperator{O<:Symbolic{AbstractOperator}} <: Symbolic{AbstractOperator}
+    op::O
 end
 isexpr(::SExpOperator) = true
 iscall(::SExpOperator) = true
@@ -508,8 +510,8 @@ julia> vec(A+B)
 |A⟩⟩+|B⟩⟩
 ```
 """
-@withmetadata struct SVec <: Symbolic{AbstractKet}
-    op::Symbolic{AbstractOperator}
+@withmetadata struct SVec{O<:Symbolic{AbstractOperator}} <: Symbolic{AbstractKet}
+    op::O
 end
 isexpr(::SVec) = true
 iscall(::SVec) = true

--- a/src/QSymbolicsBase/linalg.jl
+++ b/src/QSymbolicsBase/linalg.jl
@@ -224,10 +224,10 @@ julia> dagger(U)
 U⁻¹
 ```
 """
-@withmetadata struct SDagger{T<:QObj,O<:Symbolic} <: Symbolic{T}
+@withmetadata struct SDagger{T<:QObj,O<:SymQObj} <: Symbolic{T}
     obj::O
 end
-SDagger{T}(obj::O) where {T<:QObj,O<:Symbolic} = SDagger{T,O}(obj)
+SDagger{T}(obj::O) where {T<:QObj,O<:SymQObj} = SDagger{T,O}(obj)
 isexpr(::SDagger) = true
 iscall(::SDagger) = true
 arguments(x::SDagger) = [x.obj]

--- a/src/QSymbolicsBase/literal_objects.jl
+++ b/src/QSymbolicsBase/literal_objects.jl
@@ -3,11 +3,11 @@
 ##
 
 """Symbolic bra"""
-struct SBra <: Symbolic{AbstractBra}
+struct SBra{B<:Basis} <: Symbolic{AbstractBra}
     name::Symbol
-    basis::Basis
+    basis::B
 end
-SBra(name) = SBra(name, qubit_basis)
+SBra(name::Symbol) = SBra(name, qubit_basis)
 
 """
     @bra(name, basis=SpinBasis(1//2))
@@ -30,11 +30,11 @@ macro bra(name)
 end
 
 """Symbolic ket"""
-struct SKet <: Symbolic{AbstractKet}
+struct SKet{B<:Basis} <: Symbolic{AbstractKet}
     name::Symbol
-    basis::Basis
+    basis::B
 end
-SKet(name) = SKet(name, qubit_basis)
+SKet(name::Symbol) = SKet(name, qubit_basis)
 
 """
     @ket(name, basis=SpinBasis(1//2))
@@ -57,11 +57,11 @@ macro ket(name)
 end
 
 """Symbolic operator"""
-struct SOperator <: Symbolic{AbstractOperator}
+struct SOperator{B<:Basis} <: Symbolic{AbstractOperator}
     name::Symbol
-    basis::Basis
+    basis::B
 end
-SOperator(name) = SOperator(name, qubit_basis)
+SOperator(name::Symbol) = SOperator(name, qubit_basis)
 
 """
     @op(name, basis=SpinBasis(1//2))
@@ -86,41 +86,41 @@ ishermitian(x::SOperator) = false
 isunitary(x::SOperator) = false
 
 """Symbolic Hermitian operator"""
-struct SHermitianOperator <: Symbolic{AbstractOperator}
+struct SHermitianOperator{B<:Basis} <: Symbolic{AbstractOperator}
     name::Symbol
-    basis::Basis
+    basis::B
 end
-SHermitianOperator(name) = SHermitianOperator(name, qubit_basis)
+SHermitianOperator(name::Symbol) = SHermitianOperator(name, qubit_basis)
 
 ishermitian(::SHermitianOperator) = true
 isunitary(::SHermitianOperator) = false
 
 """Symbolic unitary operator"""
-struct SUnitaryOperator <: Symbolic{AbstractOperator}
+struct SUnitaryOperator{B<:Basis} <: Symbolic{AbstractOperator}
     name::Symbol
-    basis::Basis
+    basis::B
 end
-SUnitaryOperator(name) = SUnitaryOperator(name, qubit_basis)
+SUnitaryOperator(name::Symbol) = SUnitaryOperator(name, qubit_basis)
 
 ishermitian(::SUnitaryOperator) = false
 isunitary(::SUnitaryOperator) = true
 
 """Symbolic Hermitian and unitary operator"""
-struct SHermitianUnitaryOperator <: Symbolic{AbstractOperator}
+struct SHermitianUnitaryOperator{B<:Basis} <: Symbolic{AbstractOperator}
     name::Symbol
-    basis::Basis
+    basis::B
 end
-SHermitianUnitaryOperator(name) = SHermitianUnitaryOperator(name, qubit_basis)
+SHermitianUnitaryOperator(name::Symbol) = SHermitianUnitaryOperator(name, qubit_basis)
 
 ishermitian(::SHermitianUnitaryOperator) = true
 isunitary(::SHermitianUnitaryOperator) = true
 
 """Symbolic superoperator"""
-struct SSuperOperator <: Symbolic{AbstractSuperOperator}
+struct SSuperOperator{B<:Basis} <: Symbolic{AbstractSuperOperator}
     name::Symbol
-    basis::Basis
+    basis::B
 end
-SSuperOperator(name) = SSuperOperator(name, qubit_basis)
+SSuperOperator(name::Symbol) = SSuperOperator(name, qubit_basis)
 macro superop(name, basis)
     :($(esc(name)) = SSuperOperator($(Expr(:quote, name)), $(basis)))
 end

--- a/src/QSymbolicsBase/predefined.jl
+++ b/src/QSymbolicsBase/predefined.jl
@@ -7,33 +7,33 @@ isexpr(::SpecialKet) = false
 basis(x::SpecialKet) = x.basis
 Base.show(io::IO, x::SpecialKet) = print(io, "|$(symbollabel(x))⟩")
 
-@withmetadata struct XBasisState <: SpecialKet
+@withmetadata struct XBasisState{B<:Basis} <: SpecialKet
     idx::Int
-    basis::Basis
+    basis::B
 end
 symbollabel(x::XBasisState) = "X$(num_to_sub(x.idx))"
 
-@withmetadata struct YBasisState <: SpecialKet
+@withmetadata struct YBasisState{B<:Basis} <: SpecialKet
     idx::Int
-    basis::Basis
+    basis::B
 end
 symbollabel(x::YBasisState) = "Y$(num_to_sub(x.idx))"
 
-@withmetadata struct ZBasisState <: SpecialKet
+@withmetadata struct ZBasisState{B<:Basis} <: SpecialKet
     idx::Int
-    basis::Basis
+    basis::B
 end
 symbollabel(x::ZBasisState) = "Z$(num_to_sub(x.idx))"
 
-@withmetadata struct MomentumEigenState <: SpecialKet
-    p::Number # TODO parameterize
-    basis::Basis
+@withmetadata struct MomentumEigenState{T<:Number,B<:Basis} <: SpecialKet
+    p::T
+    basis::B
 end
 symbollabel(x::MomentumEigenState) = "δₚ($(x.p))"
 
-@withmetadata struct PositionEigenState <: SpecialKet
-    x::Float64 # TODO parameterize
-    basis::Basis
+@withmetadata struct PositionEigenState{T<:Real,B<:Basis} <: SpecialKet
+    x::T
+    basis::B
 end
 symbollabel(x::PositionEigenState) = "δₓ($(x.x))"
 
@@ -66,10 +66,10 @@ basis(::AbstractTwoQubitGate) = qubit_basis⊗qubit_basis
 Base.show(io::IO, x::AbstractSingleQubitOp) = print(io, "$(symbollabel(x))")
 Base.show(io::IO, x::AbstractTwoQubitOp) = print(io, "$(symbollabel(x))")
 
-@withmetadata struct OperatorEmbedding <: Symbolic{AbstractOperator}
-    gate::Symbolic{AbstractOperator} # TODO parameterize
+@withmetadata struct OperatorEmbedding{O<:Symbolic{AbstractOperator},B<:Basis} <: Symbolic{AbstractOperator}
+    gate::O
     indices::Vector{Int}
-    basis::Basis
+    basis::B
 end
 isexpr(::OperatorEmbedding) = true
 
@@ -179,8 +179,8 @@ julia> express(MixedState(X1⊗X2), CliffordRepr())
 + _Z
 ```
 """
-@withmetadata struct MixedState <: Symbolic{AbstractOperator}
-    basis::Basis # From QuantumOpticsBase # TODO make QuantumInterface
+@withmetadata struct MixedState{B<:Basis} <: Symbolic{AbstractOperator}
+    basis::B
 end
 MixedState(x::Symbolic{AbstractKet}) = MixedState(basis(x))
 MixedState(x::Symbolic{AbstractOperator}) = MixedState(basis(x))
@@ -199,8 +199,8 @@ Operator(dim=2x2)
   basis: Spin(1/2)sparse([1, 2], [1, 2], ComplexF64[1.0 + 0.0im, 1.0 + 0.0im], 2, 2)
 ```
 """
-@withmetadata struct IdentityOp <: Symbolic{AbstractOperator}
-    basis::Basis # From QuantumOpticsBase # TODO make QuantumInterface
+@withmetadata struct IdentityOp{B<:Basis} <: Symbolic{AbstractOperator}
+    basis::B
 end
 IdentityOp(x::Symbolic{AbstractKet}) = IdentityOp(basis(x))
 IdentityOp(x::Symbolic{AbstractOperator}) = IdentityOp(basis(x))

--- a/src/QSymbolicsBase/predefined_CPTP.jl
+++ b/src/QSymbolicsBase/predefined_CPTP.jl
@@ -10,9 +10,9 @@ basis(x::NoiseCPTP) = x.basis
 Attenuation CPTP map, defined by the beam splitter rotation parameter `theta`
 and thermal noise parameter `noise`.
 """
-@withmetadata struct AttenuatorCPTP <: NoiseCPTP
-    theta::Real
-    noise::Real
+@withmetadata struct AttenuatorCPTP{T<:Real,N<:Real} <: NoiseCPTP
+    theta::T
+    noise::N
 end
 basis(x::AttenuatorCPTP) = inf_fock_basis
 symbollabel(x::AttenuatorCPTP) = "𝒜𝓉𝓉"
@@ -23,9 +23,9 @@ symbollabel(x::AttenuatorCPTP) = "𝒜𝓉𝓉"
 Amplification CPTP map, defined by the squeezing amplitude parameter `r`
 and thermal noise parameter `noise`.
 """
-@withmetadata struct AmplifierCPTP <: NoiseCPTP
-    r::Real
-    noise::Real
+@withmetadata struct AmplifierCPTP{R<:Real,N<:Real} <: NoiseCPTP
+    r::R
+    noise::N
 end
 basis(x::AmplifierCPTP) = inf_fock_basis
 symbollabel(x::AmplifierCPTP) = "𝒜𝓂𝓅"
@@ -39,32 +39,32 @@ Operator(dim=2x2)
  0.5+0.0im  0.0+0.0im
  0.0+0.0im  0.5+0.0im
 ```"""
-@withmetadata struct PauliNoiseCPTP <: NoiseCPTP
-    px
-    py
-    pz
+@withmetadata struct PauliNoiseCPTP{X<:Number,Y<:Number,Z<:Number} <: NoiseCPTP
+    px::X
+    py::Y
+    pz::Z
 end
 basis(x::PauliNoiseCPTP) = SpinBasis(1//2)
 symbollabel(x::PauliNoiseCPTP) = "𝒫"
 
 """Single-qubit dephasing CPTP map"""
-@withmetadata struct DephasingCPTP <: NoiseCPTP
-    p
+@withmetadata struct DephasingCPTP{P<:Number} <: NoiseCPTP
+    p::P
 end
 basis(x::DephasingCPTP) = SpinBasis(1//2)
 symbollabel(x::DephasingCPTP) = "𝒟𝓅𝒽"
 
 """Single-qubit depolarization CPTP map"""
-@withmetadata struct DepolarizationCPTP <: NoiseCPTP
-    p
-    basis::Basis
+@withmetadata struct DepolarizationCPTP{P<:Number,B<:Basis} <: NoiseCPTP
+    p::P
+    basis::B
 end
 symbollabel(x::DepolarizationCPTP) = "𝒟ℯ𝓅ℴ𝓁"
 
 """A unitary gate followed by a CPTP map"""
-@withmetadata struct GateCPTP <: NoiseCPTP
-    gate::Symbolic{AbstractOperator}
-    cptp::NoiseCPTP
+@withmetadata struct GateCPTP{G<:Symbolic{AbstractOperator},C<:NoiseCPTP} <: NoiseCPTP
+    gate::G
+    cptp::C
 end
 basis(x::GateCPTP) = basis(x.cptp)
 function Base.show(io::IO, x::GateCPTP)

--- a/src/QSymbolicsBase/predefined_fock.jl
+++ b/src/QSymbolicsBase/predefined_fock.jl
@@ -16,20 +16,20 @@ end
 symbollabel(x::FockState) = "$(x.idx)"
 
 """Coherent state in defined Fock basis."""
-@withmetadata struct CoherentState <: AbstractSingleBosonState
-    alpha::Number # TODO parameterize
+@withmetadata struct CoherentState{T<:Number} <: AbstractSingleBosonState
+    alpha::T
 end
 symbollabel(x::CoherentState) = "$(x.alpha)"
 
 """Squeezed vacuum state in defined Fock basis."""
-@withmetadata struct SqueezedState <: AbstractSingleBosonState
-    z::Number
+@withmetadata struct SqueezedState{T<:Number} <: AbstractSingleBosonState
+    z::T
 end
 symbollabel(x::SqueezedState) = "0,$(x.z)"
 
 """Two-mode squeezed vacuum state, or EPR state, in defined Fock basis."""
-@withmetadata struct TwoSqueezedState <: AbstractTwoBosonState
-    z::Number
+@withmetadata struct TwoSqueezedState{T<:Number} <: AbstractTwoBosonState
+    z::T
 end
 symbollabel(x::TwoSqueezedState) = "0,$(x.z)"
 
@@ -112,8 +112,8 @@ julia> qsimplify(phase*c, rewriter=qsimplify_fock)
 |1.2246467991473532e-16 - 1.0im⟩
 ```
 """
-@withmetadata struct PhaseShiftOp <: AbstractSingleBosonGate
-    phase::Number
+@withmetadata struct PhaseShiftOp{T<:Number} <: AbstractSingleBosonGate
+    phase::T
 end
 symbollabel(x::PhaseShiftOp) = "U($(x.phase))"
 
@@ -130,8 +130,8 @@ julia> qsimplify(displace*f, rewriter=qsimplify_fock)
 |im⟩
 ```
 """
-@withmetadata struct DisplaceOp <: AbstractSingleBosonGate
-    alpha::Number
+@withmetadata struct DisplaceOp{T<:Number} <: AbstractSingleBosonGate
+    alpha::T
 end
 symbollabel(x::DisplaceOp) = "D($(x.alpha))"
 
@@ -153,25 +153,25 @@ julia> qsimplify(S*vac, rewriter=qsimplify_fock)
 |0,π⟩
 ```
 """
-@withmetadata struct SqueezeOp <: AbstractSingleBosonGate
-    z::Number
+@withmetadata struct SqueezeOp{T<:Number} <: AbstractSingleBosonGate
+    z::T
 end
 symbollabel(x::SqueezeOp) = "S($(x.z))"
 
 """Thermal bosonic state in defined Fock basis."""
-@withmetadata struct BosonicThermalState <: AbstractSingleBosonOp
-    photons::Number
+@withmetadata struct BosonicThermalState{T<:Number} <: AbstractSingleBosonOp
+    photons::T
 end
 symbollabel(x::BosonicThermalState) = "ρₜₕ($(x.photons))"
 
 """Two-mode squeezing operator in defined Fock basis."""
-@withmetadata struct TwoSqueezeOp <: AbstractTwoBosonGate
-    z::Number
+@withmetadata struct TwoSqueezeOp{T<:Number} <: AbstractTwoBosonGate
+    z::T
 end
 symbollabel(x::TwoSqueezeOp) = "S₂($(x.z))"
 
 """Two-mode beamsplitter operator in defined Fock basis."""
-@withmetadata struct BeamSplitterOp <: AbstractTwoBosonGate
-    transmit::Number
+@withmetadata struct BeamSplitterOp{T<:Number} <: AbstractTwoBosonGate
+    transmit::T
 end
 symbollabel(x::BeamSplitterOp) = "B($(x.transmit))"

--- a/src/QSymbolicsBase/utils.jl
+++ b/src/QSymbolicsBase/utils.jl
@@ -1,12 +1,12 @@
-function prefactorscalings(xs)
-    terms = []
-    coeff = 1::Any
+"""Pull the scalar prefactors out of the terms `xs`, returning the overall coefficient
+together with the remaining unscaled objects (of the same element type as `xs`)."""
+function prefactorscalings(xs::AbstractVector{E}) where {E}
+    terms = E[]
+    coeff::SymCoeff = 1
     for x in xs
         if isa(x, SScaled)
             coeff *= x.coeff
             push!(terms, x.obj)
-        elseif isa(x, Union{Number, SymbolicUtils.BasicSymbolic, Symbolic{Complex}})
-            coeff *= x
         else
             push!(terms,x)
         end
@@ -14,10 +14,16 @@ function prefactorscalings(xs)
     coeff, terms
 end
 
-function flattenop(f, terms)
-    newterms = []
+"""Flatten the nested applications of an associative operation, i.e. splice the arguments of
+the terms that are themselves of type `C` (an `SMulOperator` or an `STensor`) into the result.
+
+Only the terms of that very type are spliced: other expressions that happen to be products as
+well (e.g. an `SOuterKetBra`, or the scalings taken care of by `prefactorscalings`) are kept
+as single terms."""
+function flattenop(::Type{C}, terms::AbstractVector{E}) where {C,E}
+    newterms = E[]
     for obj in terms
-        if isexpr(obj) && operation(obj) === f
+        if isa(obj, C)
             append!(newterms, arguments(obj))
         else
             push!(newterms, obj)
@@ -34,16 +40,18 @@ function countmap(samples) # A simpler version of StatsBase.countmap, because St
     counts
 end
 
-function countmap_flatten(samples, flattenadd, flattenmul)
-    counts = Dict{Any,Any}()
+"""Accumulate the coefficients of the repeated terms of a sum in a `Dict{K,Any}`, flattening
+the nested sums (of type `ADD`) and pulling out the scalings (of type `MUL`) encountered."""
+function countmap_flatten(samples, ::Type{ADD}, ::Type{MUL}, ::Type{K}) where {ADD,MUL,K}
+    counts = Dict{K,Any}()
     for s in samples
-        if s isa flattenadd
+        if s isa ADD
             for (term,coef) in pairs(s.dict)
                 counts[term] = get(counts, term, 0)+coef
             end
-        elseif s isa flattenmul
+        elseif s isa MUL
             coef, term = arguments(s)
-            if term isa flattenadd
+            if term isa ADD
                 for (_term,_coef) in pairs(term.dict)
                     counts[_term] = get(counts, _term, 0)+coef*_coef
                 end

--- a/src/QSymbolicsBase/utils.jl
+++ b/src/QSymbolicsBase/utils.jl
@@ -40,10 +40,10 @@ function countmap(samples) # A simpler version of StatsBase.countmap, because St
     counts
 end
 
-"""Accumulate the coefficients of the repeated terms of a sum in a `Dict{K,Any}`, flattening
+"""Accumulate the coefficients of the repeated terms of a sum in a `Dict{K,SymCoeff}`, flattening
 the nested sums (of type `ADD`) and pulling out the scalings (of type `MUL`) encountered."""
 function countmap_flatten(samples, ::Type{ADD}, ::Type{MUL}, ::Type{K}) where {ADD,MUL,K}
-    counts = Dict{K,Any}()
+    counts = Dict{K,SymCoeff}()
     for s in samples
         if s isa ADD
             for (term,coef) in pairs(s.dict)

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -18,12 +18,10 @@ Ket(dim=2)
   0.7071067811865475 + 0.0im
  -0.7071067811865475 + 0.0im
 ```"""
-@withmetadata struct StabilizerState{T} <: Symbolic{AbstractKet} where {T}
-    stabilizer::T
+@withmetadata struct StabilizerState{T} <: Symbolic{AbstractKet}
+    stabilizer::T # a `QuantumClifford.MixedDestabilizer`, only available when that library is loaded
 end
 isexpr(::StabilizerState) = false
 basis(x::StabilizerState) = SpinBasis(1//2)^nqubits(x.stabilizer)
 symbollabel(x::StabilizerState) = "𝒮$(num_to_sub(nqubits(x.stabilizer)))"
 Base.show(io::IO, x::StabilizerState) = print(io, symbollabel(x))
-
-StabilizerState(s::T) where {T} = StabilizerState{T}(s) # TODO this is necessary because the @withmetadata macro is not very smart

--- a/test/general/struct_types_tests.jl
+++ b/test/general/struct_types_tests.jl
@@ -1,0 +1,173 @@
+using Test
+using QuantumSymbolics
+using QuantumSymbolics: @withmetadata, Metadata # `Metadata` is what the macro puts in the field
+
+"""A decorated struct defined outside of any testset, so that its constructors can be inspected."""
+@withmetadata struct FieldTypeTestStruct{T}
+    a::T
+end
+
+##
+# All the fields of all the structs of this library have to be (concretely) typed, either
+# directly or through a type parameter, so that every instantiated symbolic object has a
+# fixed memory layout and type-stable field access.
+##
+
+@testset "Concretely typed struct fields" begin
+    import QuantumClifford # for StabilizerState (both packages export `X`, `Y` and `Z`)
+    import QuantumOptics # to load the QuantumOptics and MixedCliffordOptics extensions
+    using QuantumInterface: AbstractBra, AbstractOperator
+    using QuantumSymbolics:
+        inf_fock_basis, qubit_basis,
+        MomentumEigenState, PositionEigenState, OperatorEmbedding, DepolarizationCPTP
+
+    """All the struct types (excluding the callable objects) defined in a module."""
+    function struct_types(m::Module)
+        types = Set{Any}()
+        for n in names(m; all=true)
+            isdefined(m, n) || continue
+            x = getproperty(m, n)
+            x isa Type || continue
+            T = Base.unwrap_unionall(x)
+            T isa DataType || continue
+            Base.isstructtype(T) || continue
+            T <: Function && continue
+            parentmodule(T) === m || continue # skip the imported and re-exported types
+            push!(types, T.name.wrapper)
+        end
+        types
+    end
+
+    """Whether a declared field type is concrete for every concrete instantiation of its struct."""
+    function isspecified(fieldtype)
+        fieldtype isa TypeVar && return true # given by a type parameter
+        fieldtype === Any && return false
+        isconcretetype(fieldtype) && return true
+        # e.g. `Dict{Symbolic{T},Any}` is concrete as soon as `T` is fixed
+        fieldtype isa DataType && !isabstracttype(fieldtype) && return true
+        false
+    end
+
+    underspecified(T) = [n=>t for (n,t) in zip(fieldnames(T), fieldtypes(T)) if !isspecified(t)]
+
+    @testset "no underspecified field in any declaration" begin
+        for m in (QuantumSymbolics,
+                  Base.get_extension(QuantumSymbolics, :QuantumOpticsExt),
+                  Base.get_extension(QuantumSymbolics, :QuantumCliffordExt),
+                  Base.get_extension(QuantumSymbolics, :MixedCliffordOpticsExt))
+            isnothing(m) && continue
+            for T in struct_types(m)
+                bad = underspecified(Base.unwrap_unionall(T))
+                isempty(bad) || @error "underspecified fields" T bad
+                @test isempty(bad)
+            end
+        end
+    end
+
+    # A representative object for every struct of the library. The coverage of this list is
+    # checked below, so a newly added struct has to be given a representative here as well.
+    @op A; @op B; @op C; @ket k; @bra b; @superop S₁; @superop S₂;
+    @op 𝒪 qubit_basis⊗qubit_basis;
+    corpus = Any[
+        # literal objects and the zero objects
+        k, b, A, S₁,
+        SHermitianOperator(:ℋ), SUnitaryOperator(:U), SHermitianUnitaryOperator(:V),
+        zero(k), zero(b), zero(A), zero(S₁),
+        # homogeneous operations
+        2*k, 2*b, 2*A, im*A, tr(A)*A,
+        k+k*2, b+2*b, A+2*B,
+        A*B,
+        k⊗k, b⊗b, A⊗B, S₁⊗S₂,
+        # inhomogeneous operations
+        A*k, b*A, b*k, k*b,
+        # superoperators
+        kraus(A,B), S₁*A,
+        # linear algebra
+        commutator(A,B), anticommutator(A,B),
+        conj(A), conj(k), transpose(A), transpose(k),
+        dagger(A), dagger(k), dagger(b),
+        projector(k), tr(A), ptrace(𝒪, 1), inv(A), exp(A), vec(A),
+        # scalar expressions
+        2*tr(A), tr(A)+tr(B), tr(A)*tr(B),
+        # qubit states and gates
+        X1, Y1, Z1, X, Y, Z, H, Pm, Pp, CNOT, CPHASE,
+        XCX, XCY, XCZ, YCX, YCY, YCZ, ZCX, ZCY, ZCZ,
+        # other predefined objects
+        MixedState(k), IdentityOp(k), OperatorEmbedding(X, [1], qubit_basis⊗qubit_basis),
+        MomentumEigenState(1.0, inf_fock_basis), PositionEigenState(1.0, inf_fock_basis),
+        # harmonic oscillator states and operators
+        FockState(1), CoherentState(im), SqueezedState(pi/4), TwoSqueezedState(pi/4),
+        BosonicThermalState(2), N, Create, Destroy,
+        PhaseShiftOp(pi), DisplaceOp(im), SqueezeOp(pi/4), TwoSqueezeOp(pi/4), BeamSplitterOp(0.5),
+        # CPTP maps
+        PauliNoiseCPTP(1/4,1/4,1/4), DephasingCPTP(1/4), DepolarizationCPTP(1/4, qubit_basis),
+        AttenuatorCPTP(pi/4, 1), AmplifierCPTP(2.0, 1), GateCPTP(X, DephasingCPTP(1/4)),
+        # backend dependent objects
+        StabilizerState("XZ YY"),
+        # bookkeeping objects
+        Metadata(), QuantumToolboxRepr(),
+    ]
+
+    @testset "no underspecified field in any instantiation" begin
+        for x in corpus
+            T = typeof(x)
+            bad = underspecified(T)
+            isempty(bad) || @error "underspecified fields" T bad
+            @test isconcretetype(T)
+            @test isempty(bad)
+            @test all(isconcretetype, fieldtypes(T))
+        end
+    end
+
+    @testset "every struct has a representative above" begin
+        covered = Set(Base.typename(typeof(x)).wrapper for x in corpus)
+        missed = setdiff(struct_types(QuantumSymbolics), covered)
+        isempty(missed) || @error "structs without a representative in the test corpus" missed
+        @test isempty(missed)
+    end
+
+    @testset "type parameters are inferred from the arguments" begin
+        @test SKet(:k) === SKet(:k, qubit_basis)
+        @test typeof(SKet(:k)) == SKet{typeof(qubit_basis)}
+        @test typeof(2*A) == SScaled{AbstractOperator,Int,typeof(A)}
+        @test typeof(A*k) == SApplyKet{typeof(A),typeof(k)}
+        @test typeof(dagger(k)) == SDagger{AbstractBra,typeof(k)}
+        @test typeof(CoherentState(im)) == CoherentState{Complex{Bool}}
+        @test typeof(DisplaceOp(1.0)) == DisplaceOp{Float64}
+        @test 2*A isa SScaledOperator && 2*A isa SScaled{AbstractOperator}
+        @test A+B isa SAddOperator && A⊗B isa STensorOperator
+    end
+
+    @testset "the type parameters do not change what is equal" begin
+        @test isequal(CoherentState(1), CoherentState(1.0)) # as `isequal(1, 1.0)` is true
+        @test isequal(2*A, 2.0*A)
+        @test !isequal(CoherentState(1), CoherentState(2))
+        @test !isequal(SKet(:k), SKet(:k, FockBasis(2))) # same struct, different basis
+        @test !isequal(zero(k), zero(b)) # same struct, different kind of quantum object
+        @test hash(zero(k)) != hash(zero(b))
+        @test !isequal(A*B, A*B*C) # products of different lengths
+        @test !isequal(A⊗B, A⊗B⊗C)
+    end
+
+    @testset "the generated constructor keeps the default ones suppressed" begin
+        # The metadata is the last field, so Julia's default constructors would take it as their
+        # last argument. Those must not exist: downstream packages add constructors of their own
+        # to these structs, and a method of the same arity would silently overwrite a generated
+        # one -- which is an error during precompilation (QuantumSavory does exactly this).
+        @test typeof(FieldTypeTestStruct(1)) == FieldTypeTestStruct{Int}
+        @test hasmethod(FieldTypeTestStruct, Tuple{Any})
+        @test !hasmethod(FieldTypeTestStruct, Tuple{Any,Any})
+        for T in (SProjector, SApplyKet, SScaled, MixedState, CoherentState, KrausRepr, SMulOperator)
+            nargs = fieldcount(Base.unwrap_unionall(T)) # the fields, metadata included
+            @test !hasmethod(T, Tuple{fill(Any, nargs)...})
+        end
+    end
+
+    @testset "the metadata field is added last and stays out of the way" begin
+        @test fieldnames(typeof(2*A))[end] == :metadata
+        @test QuantumSymbolics.metadata(2*A) isa Metadata
+        @test isnothing(QuantumSymbolics.metadata(A)) # literal objects are not cached
+        @test isequal(2*A, 2*A) # the metadata is excluded from the comparisons
+        @test hash(2*A) == hash(2*A)
+    end
+end

--- a/test/general/struct_types_tests.jl
+++ b/test/general/struct_types_tests.jl
@@ -7,6 +7,12 @@ using QuantumSymbolics: @withmetadata, Metadata # `Metadata` is what the macro p
     a::T
 end
 
+"""The same, without a type parameter: only for such a struct does Julia generate the untyped
+default constructor that the inner one has to suppress."""
+@withmetadata struct PlainFieldTypeTestStruct
+    a::Int
+end
+
 ##
 # All the fields of all the structs of this library have to be (concretely) typed, either
 # directly or through a type parameter, so that every instantiated symbolic object has a
@@ -16,6 +22,7 @@ end
 @testset "Concretely typed struct fields" begin
     import QuantumClifford # for StabilizerState (both packages export `X`, `Y` and `Z`)
     import QuantumOptics # to load the QuantumOptics and MixedCliffordOptics extensions
+    import Gabs, QuantumToolbox # so that all five extensions are loaded and can be scanned
     using QuantumInterface: AbstractBra, AbstractOperator
     using QuantumSymbolics:
         inf_fock_basis, qubit_basis,
@@ -51,11 +58,14 @@ end
     underspecified(T) = [n=>t for (n,t) in zip(fieldnames(T), fieldtypes(T)) if !isspecified(t)]
 
     @testset "no underspecified field in any declaration" begin
-        for m in (QuantumSymbolics,
-                  Base.get_extension(QuantumSymbolics, :QuantumOpticsExt),
-                  Base.get_extension(QuantumSymbolics, :QuantumCliffordExt),
-                  Base.get_extension(QuantumSymbolics, :MixedCliffordOpticsExt))
-            isnothing(m) && continue
+        # every extension of the package, so that a struct added to any of them is covered
+        extensions = [:QuantumOpticsExt, :QuantumCliffordExt, :MixedCliffordOpticsExt,
+                      :GabsExt, :QuantumToolboxExt]
+        modules = [QuantumSymbolics; [Base.get_extension(QuantumSymbolics, e) for e in extensions]]
+        @test !any(isnothing, modules) # the extensions have to be loaded for this to mean anything
+        # and fail closed: an enumeration that silently returns nothing would pass every test below
+        @test length(struct_types(QuantumSymbolics)) >= 79
+        for m in filter(!isnothing, modules)
             for T in struct_types(m)
                 bad = underspecified(Base.unwrap_unionall(T))
                 isempty(bad) || @error "underspecified fields" T bad
@@ -154,11 +164,13 @@ end
         # last argument. Those must not exist: downstream packages add constructors of their own
         # to these structs, and a method of the same arity would silently overwrite a generated
         # one -- which is an error during precompilation (QuantumSavory does exactly this).
+        # Julia only generates that untyped constructor for a struct without type parameters, so
+        # the parameter-free probe is the one that actually exercises the regression.
         @test typeof(FieldTypeTestStruct(1)) == FieldTypeTestStruct{Int}
-        @test hasmethod(FieldTypeTestStruct, Tuple{Any})
-        @test !hasmethod(FieldTypeTestStruct, Tuple{Any,Any})
-        for T in (SProjector, SApplyKet, SScaled, MixedState, CoherentState, KrausRepr, SMulOperator)
-            nargs = fieldcount(Base.unwrap_unionall(T)) # the fields, metadata included
+        @test hasmethod(PlainFieldTypeTestStruct, Tuple{Any})
+        @test !hasmethod(PlainFieldTypeTestStruct, Tuple{Any,Any})
+        for T in (KrausRepr, SMulOperator) # the package's own structs without type parameters
+            nargs = fieldcount(T) # the fields, metadata included
             @test !hasmethod(T, Tuple{fill(Any, nargs)...})
         end
     end


### PR DESCRIPTION
Closes #67.

Every field of every struct now has a declared type that is concrete for any concrete
instantiation, either directly (`idx::Int`, `terms::Vector{Symbolic{T}}`) or through a type
parameter (`basis::B`, `alpha::T<:Number`, `ket::K<:Symbolic{AbstractKet}`); 52 of the 79 structs
are now parametric and no untyped or `Any` field is left. Fixed-arity children get a type parameter,
while variadic ones keep a concrete container with an abstract element type, so that the type of an
expression never depends on its size. None of this was possible before, because `@withmetadata`
hard-coded a single type parameter (`new{S}(...)`); it now carries over any number of them and adds
`Foo(fields...)` whenever every parameter is spelled out as the type of a field. It stays an *inner*
constructor on purpose: that is what keeps Julia from generating the default ones, whose last
argument would be the metadata. `QuantumSavory` defines `BarrettKokBellPairW(ηᴬ,ηᴮ)` on a one-field
decorated struct, and with an outer constructor that silently overwrites a generated method and
fails precompilation. Equality is deliberately left alone: `isequal`/`hash` compared `typeof`, which
would have made `CoherentState(1) != CoherentState(1.0)`, so they now compare the struct plus the
kind of quantum object (`samekind`/`qobjtype`), keeping the field values as what decides equality
while `zero(ket)` and `zero(bra)` stay distinct.

The stricter types surfaced three latent bugs, each fixed here: `flattenop` spliced *any* `*`-headed
term into an operator product, so a ket and a bra could end up inside `SMulOperator.terms`;
`inv(A)*B` threw a `MethodError`; and `isequal` compared arguments with `zip`, making `A*B` equal to
`A*B*C`. A new `test/general/struct_types_tests.jl` locks the invariant in: no field of any struct
in the package or its extensions may be underspecified, every field of a representative instance
must be concrete, and the corpus must cover *every* struct, so a newly added struct without a
representative fails the suite. The `general` suite goes from 450 pass, 2 broken to 852 pass, 2
broken with no failures, downstream `QuantumSavory` precompiles clean and passes (14153 pass, 8
broken), and `jet` drops from 2 reports to 1, the remaining one being a pre-existing missing `show`
for a sum of superoperators that JET can only now see, left alone since fixing it would turn the
`@test_broken` in `jet_tests.jl` into an unexpected pass. Diffing ~150 objects against `main`
through `show`, `latexify`, `isequal`/`hash`, `qsimplify`, `qexpand`, `basis` and `express` in both
the QuantumOptics and the Clifford representations gives identical output, except that `latexify` of
a sum can order its terms differently, following the changed hash of the literal objects, an order
that comes out of a `Dict` and has never been meaningful, which is why `show` sorts.

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs. <small>No new user facing functionality; the docstrings of the touched types, of `@withmetadata` and of the helpers in `utils.jl` were updated.</small>
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass. <small>Everything passes locally (`general`, `jet`, the doctests, Aqua, the benchmarks and the downstream `QuantumSavory` suite); to be ticked once CI has run.</small>
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.

If you are submitting for a bug bounty:
- [x] I have read and followed the [AI usage and disclosure policy](https://github.com/QuantumSavory/.github/blob/main/BUG_BOUNTIES.md)

AI Disclosure: I used Claude Fabel to initially understand the problem, code scaffolding, adding comments, documentation, and getting full test coverage.