### PR TITLE
Complete Clifford Pauli-observable lowering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.4.17 - 2026-08-06
+
+- **(fix)** Complete Clifford observable lowering for symbolic Pauli tensors, identities, and native `PauliOperator`s.
+
 ## v0.4.16 - 2026-04-01
 
 - Add `QuantumClifford.Register` symbolic `apply!` methods to the `QuantumClifford` extension.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumSymbolics"
 uuid = "efa7fd63-0460-4890-beb7-be1bbdfbaeae"
 authors = ["QuantumSymbolics.jl contributors"]
-version = "0.4.16"
+version = "0.4.17"
 
 [workspace]
 projects = ["benchmark", "docs"]

--- a/ext/QuantumCliffordExt/QuantumCliffordExt.jl
+++ b/ext/QuantumCliffordExt/QuantumCliffordExt.jl
@@ -50,8 +50,16 @@ express_nolookup(::ZGate,            ::CliffordRepr, ::UseAsOperation) = Quantum
 express_nolookup(::HGate,            ::CliffordRepr, ::UseAsOperation) = QuantumClifford.sHadamard
 express_nolookup(x::STensorOperator,  r::CliffordRepr, u::UseAsOperation) = QCGateSequence([express(t,r,u) for t in x.terms])
 
+function _basis_width(b)
+    bases = b isa CompositeBasis ? b.bases : (b,)
+    all(b -> length(b) == 2, bases) || throw(ArgumentError("Clifford Pauli observables require two-dimensional subsystem bases."))
+    length(bases)
+end
+
+express(op::QuantumClifford.PauliOperator, ::CliffordRepr, ::UseAsObservable) = op
 express_nolookup(op::QuantumClifford.PauliOperator, ::CliffordRepr, ::UseAsObservable) = op
-express_nolookup(op::STensorOperator, r::CliffordRepr, u::UseAsObservable) = QuantumClifford.tensor(express.(arguments(op),(r,),(u,))...)
+express_nolookup(op::STensorOperator, r::CliffordRepr, u::UseAsObservable) = foldl(QuantumClifford.tensor, (express(t,r,u) for t in arguments(op)))
+express_nolookup(op::IdentityOp, ::CliffordRepr, ::UseAsObservable) = zero(QuantumClifford.PauliOperator, _basis_width(basis(op)))
 express_nolookup(::XGate, ::CliffordRepr, ::UseAsObservable) = QuantumClifford.P"X"
 express_nolookup(::YGate, ::CliffordRepr, ::UseAsObservable) = QuantumClifford.P"Y"
 express_nolookup(::ZGate, ::CliffordRepr, ::UseAsObservable) = QuantumClifford.P"Z"
@@ -78,9 +86,8 @@ function express_from_cache(x::QCRandomSampler)
     express_from_cache(x.operators[i])
 end
 function express_nolookup(x::MixedState, ::CliffordRepr)
-    nqubits = isa(x.basis, CompositeBasis) ? length(x.basis.bases) : 1
     # TODO assert all are qubits
-    one(MixedDestabilizer,0,nqubits)
+    one(MixedDestabilizer,0,_basis_width(basis(x)))
 end
 express_nolookup(x::SProjector, repr::CliffordRepr) = express_nolookup(x.ket, repr)
 

--- a/test/general/express_cliff_tests.jl
+++ b/test/general/express_cliff_tests.jl
@@ -27,27 +27,33 @@ using QuantumClifford
     UseObs = UseAsObservable()
 
     @testset "Clifford representations for basis states" begin
-        isequal(express(X1, CR), MixedDestabilizer(S"X"))
-        isequal(express(X2, CR), MixedDestabilizer(S"-X"))
-        isequal(express(Y1, CR), MixedDestabilizer(S"Y"))
-        isequal(express(Y2, CR), MixedDestabilizer(S"-Y"))
-        isequal(express(Z1, CR), MixedDestabilizer(S"Z"))
-        isequal(express(Z2, CR), MixedDestabilizer(S"-Z"))
+        @test isequal(express(X1, CR), MixedDestabilizer(S"X"))
+        @test isequal(express(X2, CR), MixedDestabilizer(S"-X"))
+        @test isequal(express(Y1, CR), MixedDestabilizer(S"Y"))
+        @test isequal(express(Y2, CR), MixedDestabilizer(S"-Y"))
+        @test isequal(express(Z1, CR), MixedDestabilizer(S"Z"))
+        @test isequal(express(Z2, CR), MixedDestabilizer(S"-Z"))
     end
 
     @testset "Clifford representations as observables" begin
-        isequal(express(σˣ, CR, UseObs), P"X")
-        isequal(express(σʸ, CR, UseObs), P"Y")
-        isequal(express(σᶻ, CR, UseObs), P"Z")
-        isequal(express(im*σˣ, CR, UseObs), im*P"X")
-        isequal(express(σˣ⊗σʸ⊗σᶻ), P"X"⊗P"Y"⊗P"Z")
-        isequal(express(σˣ*σʸ*σᶻ), P"X"*P"Y"*P"Z")
+        @test isequal(express(σˣ, CR, UseObs), P"X")
+        @test isequal(express(σʸ, CR, UseObs), P"Y")
+        @test isequal(express(σᶻ, CR, UseObs), P"Z")
+        @test isequal(express(im*σˣ, CR, UseObs), im*P"X")
+        @test isequal(express(σˣ⊗σʸ⊗σᶻ, CR, UseObs), P"XYZ")
+        @test isequal(express(σˣ*σʸ*σᶻ, CR, UseObs), P"X"*P"Y"*P"Z")
+        @test isequal(express(σˣ⊗QuantumSymbolics.I⊗σᶻ, CR, UseObs), P"XIZ")
+        @test isequal(express(σˣ⊗IdentityOp(σʸ⊗σᶻ)⊗σˣ, CR, UseObs), P"XIIX")
+        @test_throws ArgumentError express(IdentityOp(FockBasis(3)), CR, UseObs)
+
+        native = QuantumClifford.P"XYZ"
+        @test QuantumSymbolics.express(native, CR, UseObs) == native
     end
 
     @testset "Clifford representations as operations" begin
-        isequal(express(σˣ, CR, UseOp), sX)
-        isequal(express(σʸ, CR, UseOp), sY)
-        isequal(express(σᶻ, CR, UseOp), sZ)
+        @test isequal(express(σˣ, CR, UseOp), sX)
+        @test isequal(express(σʸ, CR, UseOp), sY)
+        @test isequal(express(σᶻ, CR, UseOp), sZ)
     end
 
     @testset "Projector on stab state" begin


### PR DESCRIPTION
Related to [QuantumSavory.jl issue #301](https://github.com/QuantumSavory/QuantumSavory.jl/issues/301).

## Problem

Issue #301 exposed three gaps in Clifford observable lowering:

- symbolic Pauli tensors with three or more factors entered a faulty QuantumClifford vararg tensor path;
- symbolic tensors containing `I` could not lower to a correctly sized Clifford Pauli;
- the intended raw `QuantumClifford.PauliOperator` observable interoperability path was unreachable.

## Change

- Lower `STensorOperator` observables with a binary `foldl(QuantumClifford.tensor, ...)`.
- Use one private basis-width helper to lower `IdentityOp` to a correctly sized `PauliOperator` and reject non-qubit identity bases.
- Add the exact native interoperability method for `QuantumClifford.PauliOperator`, `CliffordRepr`, and `UseAsObservable`.
- Do not add a generic non-symbolic fallback.
- Convert the existing inert Clifford checks to real `@test` assertions with explicit representation and use-mode arguments.
- Add readable coverage for three-factor tensors, one- and multi-qubit identities, scaled/product expressions, and qualified native Pauli pass-through.
- Set the package version to `0.4.17` and add the matching changelog entry.

## Design choice

Selected: repeated binary tensor lowering, one private basis-width helper, and one exact native-Pauli interoperability method.

Rejected: splatting into QuantumClifford's vararg path, raising the QuantumClifford compatibility floor, or adding a generic non-symbolic fallback. Those alternatives would either retain the defect or unnecessarily reduce/broaden compatibility.

## Validation

- `general/express_cliff`: 29 passed.
- Full QuantumSymbolics suite: 469 passed and 2 existing broken tests.
- QuantumClifford 0.10.1 focused compatibility run: 29 passed.
- QuantumClifford 0.11 focused compatibility run: passed.
- QuantumClifford 0.9.4 binary tensor API probe: passed.

A complete QuantumClifford 0.9-focused environment cannot resolve because that release requires QuantumInterface 0.3 while current QuantumSymbolics requires QuantumInterface 0.4.1 or later. This is a pre-existing environment constraint. The binary tensor API used by this PR was verified directly against QuantumClifford 0.9.4.

## Compatibility and dependencies

- Declared QuantumClifford compatibility remains unchanged at 0.9, 0.10, and 0.11.
- This PR does **not** depend on [QuantumClifford.jl #776](https://github.com/QuantumSavory/QuantumClifford.jl/pull/776). Binary folding deliberately avoids the native vararg defect and preserves compatibility with existing releases.
- QuantumClifford.jl #776 remains the direct native `PauliOperator` vararg fix; it is complementary, not a prerequisite.
- No QuantumSavory source or compatibility change is included here. The indexed stabilizer-projector correction in [QuantumSavory.jl #518](https://github.com/QuantumSavory/QuantumSavory.jl/pull/518) is independent and needs only registered QuantumClifford 0.11.6.

## Registration and downstream sequence

After merge, **QuantumSymbolics `0.4.17` must be registered in General** ([registered versions](https://github.com/JuliaRegistries/General/blob/master/Q/QuantumSymbolics/Versions.toml)).

The downstream QuantumSavory PR that raises its QuantumSymbolics minimum and adds the public seven-qubit issue-301 regression must wait until a clean environment resolves registered `QuantumSymbolics 0.4.17` without a path or Git override. That downstream PR will use only exported symbolic `X`, `Y`, `Z`, and `I` factors and does not depend on QuantumClifford `0.11.7`.

The downstream compatibility/regression PR is intentionally not opened yet: registration, not merely this Git branch, is its prerequisite. [QuantumSavory.jl #522](https://github.com/QuantumSavory/QuantumSavory.jl/pull/522) documents the resulting backend-neutral route and remains a draft until that registered-dependency PR lands.

This PR references issue #301 but does not close it; issue closure waits for all fixes and the QuantumSavory `0.7.1` release.
