### PR TITLE
Remove obsolete Buildkite coverage options

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,8 +14,7 @@ steps:
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
           test_args: "general"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
+      - JuliaCI/julia-coverage#v1: ~
 
   - label: "General Tests (alpha)"
     plugins:
@@ -24,8 +23,7 @@ steps:
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
           test_args: "general"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
+      - JuliaCI/julia-coverage#v1: ~
 
   - label: "JET Tests"
     plugins:
@@ -34,8 +32,7 @@ steps:
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
           test_args: "jet"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
+      - JuliaCI/julia-coverage#v1: ~
 
   - label: "Docs"
     branches: "!dependabot/*"


### PR DESCRIPTION
Summary:
- remove the unsupported codecov option from all Julia coverage plugin uses
- retain coverage uploads through the current plugin default behavior

Checks:
- bk pipeline validate
- verified no codecov option remains in the pipeline YAML