### PR TITLE
Require current ParallelTestRunner in downgrade tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -22,3 +22,6 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
+
+[compat]
+ParallelTestRunner = "2.7.0"


### PR DESCRIPTION
## Summary

- set the test-environment ParallelTestRunner lower bound to 2.7.0, the latest General-registry release
- prevent minimum-dependency CI from selecting ParallelTestRunner 0.1.0, which does not provide the find_tests API used by this suite

## Validation

- Project.toml and test/Project.toml parse with Julia 1.12.6
- ParallelTestRunner 2.7.0 supports the package Julia 1.10 floor
- git diff --check
- hosted downgrade CI provides the locked minimum-version integration test