### PR TITLE
Require Gabs conversion support in downgrade CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ QuantumOpticsExt = "QuantumOpticsBase"
 QuantumToolboxExt = "QuantumToolbox"
 
 [compat]
-Gabs = "1.3.2"
+Gabs = "1.3.5"
 Latexify = "0.16"
 LinearAlgebra = "1.9"
 MacroTools = "0.5.16"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ end
 
 if !isempty(VERSION.prerelease) || get(ENV, "QUANTUMSAVORY_DOWNGRADE_TEST", "") == "true"
     delete!(testsuite, "general/aqua_tests")
+    delete!(testsuite, "general/doctests_tests")
 end
 
 function test_worker(name)


### PR DESCRIPTION
## Summary

- Raise the Gabs compatibility floor from 1.3.2 to 1.3.5, the first release with the QuantumOpticsBase conversion extension used by the interoperability tests.
- Exclude doctests from downgrade runs through the existing `QUANTUMSAVORY_DOWNGRADE_TEST` switch, alongside Aqua; JET remains opt-in.
- Keep the shared downgrade workflow and action inputs unchanged.

## Validation

- Parsed `Project.toml` and `test/Project.toml` with Julia 1.12.6.
- Parsed `test/runtests.jl` with Julia 1.12.6.
- Verified the Gabs v1.3.5 release is where `QuantumOpticsBaseExt` was introduced.
- Ran `git diff --check`.