### PR TITLE
Add symbolic Pauli eigenvalues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.4.18 - 2026-08-27
+
+- Add aligned eigenvalues for the symbolic Pauli eigenbases returned by `eigvecs`.
+
 ## v0.4.17 - 2026-08-06
 
 - **(fix)** Complete Clifford observable lowering for symbolic Pauli tensors, identities, and native `PauliOperator`s.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumSymbolics"
 uuid = "efa7fd63-0460-4890-beb7-be1bbdfbaeae"
 authors = ["QuantumSymbolics.jl contributors"]
-version = "0.4.17"
+version = "0.4.18"
 
 [workspace]
 projects = ["benchmark", "docs"]

--- a/docs/src/qubit_basis.md
+++ b/docs/src/qubit_basis.md
@@ -39,11 +39,15 @@ Above `dense` is from `QuantumOptics`, used to convert their representation to a
 The eigenvectors of each one of them provides for a convenient basis. The σᶻ basis is also called the *computational basis*. As mentioned, we have both unicode and ASCII names for convenience of typing. For these basis vectors we also have two sets of names: one based on which operator they are eigenvectors of and one in terms of typical logical representation (with prefix `L`).
 
 - `Z1 = Z₁ = L0 = L₀ = ` $|0\rangle = \begin{pmatrix}1\\0\end{pmatrix} = |\uparrow\rangle$ with eigenvalue +1 for σᶻ
-- `Z2 = Z₂ = L1 = L₁ = ` $|1\rangle = \begin{pmatrix}0\\1\end{pmatrix} = |\downarrow\rangle$ with eigenvalue +1 for σᶻ
+- `Z2 = Z₂ = L1 = L₁ = ` $|1\rangle = \begin{pmatrix}0\\1\end{pmatrix} = |\downarrow\rangle$ with eigenvalue -1 for σᶻ
 - `X1 = X₁ = Lp = L₊ = ` $|+\rangle = \frac{1}{\sqrt 2}\begin{pmatrix}1\\1\end{pmatrix}$ with eigenvalue +1 for σˣ
 - `X2 = X₂ = Lm = L₋ = ` $|-\rangle = \frac{1}{\sqrt 2}\begin{pmatrix}1\\-1\end{pmatrix}$ with eigenvalue -1 for σˣ
 - `Y1 = Y₁ = Lpi = L₊ᵢ = ` $|+i\rangle = \frac{1}{\sqrt 2}\begin{pmatrix}1\\ i\end{pmatrix}$ with eigenvalue +1 for σʸ
 - `Y2 = Y₂ = Lmi = L₋ᵢ = ` $|-i\rangle = \frac{1}{\sqrt 2}\begin{pmatrix}1\\-i\end{pmatrix}$ with eigenvalue -1 for σʸ
+
+`LinearAlgebra.eigvecs` and `LinearAlgebra.eigvals` use the same order for each
+Pauli operator: `([X1, X2], [1, -1])` for `X`, `([Y1, Y2], [1, -1])` for `Y`,
+and `([Z1, Z2], [1, -1])` for `Z`.
 
 The Y vectors occasionally are denoted with R and L (stemming from the vector notation for right and left polarized light), but there is no established notation choice or ordering.
 

--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -18,7 +18,7 @@ import MacroTools
 import MacroTools: namify, @capture
 
 using LinearAlgebra
-import LinearAlgebra: eigvecs,ishermitian,conj,transpose,inv,exp,vec,tr
+import LinearAlgebra: eigvals,eigvecs,ishermitian,conj,transpose,inv,exp,vec,tr
 
 import QuantumInterface:
     apply!,

--- a/src/QSymbolicsBase/predefined.jl
+++ b/src/QSymbolicsBase/predefined.jl
@@ -75,18 +75,21 @@ isexpr(::OperatorEmbedding) = true
 
 @withmetadata struct XGate <: AbstractSingleQubitGate end
 eigvecs(g::XGate) = [X1,X2]
+eigvals(g::XGate) = [1,-1]
 symbollabel(::XGate) = "X"
 ishermitian(::XGate) = true
 isunitary(::XGate) = true
 
 @withmetadata struct YGate <: AbstractSingleQubitGate end
 eigvecs(g::YGate) = [Y1,Y2]
+eigvals(g::YGate) = [1,-1]
 symbollabel(::YGate) = "Y"
 ishermitian(::YGate) = true
 isunitary(::YGate) = true
 
 @withmetadata struct ZGate <: AbstractSingleQubitGate end
 eigvecs(g::ZGate) = [Z1,Z2]
+eigvals(g::ZGate) = [1,-1]
 symbollabel(::ZGate) = "Z"
 ishermitian(::ZGate) = true
 isunitary(::ZGate) = true
@@ -211,4 +214,4 @@ ishermitian(::IdentityOp) = true
 isunitary(::IdentityOp) = true
 
 """Identity operator in qubit basis"""
-const I = IdentityOp(qubit_basis)   
+const I = IdentityOp(qubit_basis)

--- a/test/general/basis_consistency_tests.jl
+++ b/test/general/basis_consistency_tests.jl
@@ -1,5 +1,6 @@
 using Test
 using QuantumSymbolics
+using LinearAlgebra: eigvals, eigvecs
 
 @testset "Basis consistency" begin
     using QuantumOptics
@@ -14,6 +15,14 @@ using QuantumSymbolics
     @test express(Pp*Z2) == express(Z1)
     @test express(Pm*L0) == express(L1)
     @test express(Pp*L1) == express(L0)
+
+    for (op, states) in ((X, [X1, X2]), (Y, [Y1, Y2]), (Z, [Z1, Z2]))
+        @test eigvecs(op) == states
+        @test eigvals(op) == [1, -1]
+        for (state, value) in zip(eigvecs(op), eigvals(op))
+            @test express(op * state) == value * express(state)
+        end
+    end
 
     @op A; @op B; @op C; @op O; @ket k;
     @superop S; K = kraus(A, B, C);


### PR DESCRIPTION
## Summary

- add aligned LinearAlgebra.eigvals methods for symbolic X, Y, and Z
- test exact eigenvector/eigenvalue ordering and the eigenvector equation
- correct and document the Pauli eigenbasis ordering
- prepare QuantumSymbolics v0.4.18

This release is the prerequisite for QuantumSavory measurement outcomes that return Pauli eigenvalues.

## Checks

- focused basis consistency: 23 passed
- full general suite: 481 passed, 2 expected broken
- Aqua and doctests passed through the general suite
- independent agent review: no findings