### PR TITLE
Require nonempty symbolic tensor products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.4.19 - 2026-09-05
+
+- Require at least one argument for symbolic and QuantumOptics superoperator tensor products.
+
 ## v0.4.18 - 2026-08-27
 
 - Add aligned eigenvalues for the symbolic Pauli eigenbases returned by `eigvecs`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumSymbolics"
 uuid = "efa7fd63-0460-4890-beb7-be1bbdfbaeae"
 authors = ["QuantumSymbolics.jl contributors"]
-version = "0.4.18"
+version = "0.4.19"
 
 [workspace]
 projects = ["benchmark", "docs"]

--- a/ext/QuantumOpticsExt/should_upstream.jl
+++ b/ext/QuantumOpticsExt/should_upstream.jl
@@ -43,7 +43,8 @@ struct LazySuperTensor{B,T} <: AbstractLazySuperOperator{Tuple{B,B},Tuple{B,B}}
     sops::T
 end
 
-function QuantumInterface.tensor(sops::AbstractSuperOperator...)
+function QuantumInterface.tensor(sop::AbstractSuperOperator, sops::AbstractSuperOperator...)
+    sops = (sop, sops...)
     b = QuantumInterface.tensor(basis.(sops)...)
     @assert length(sops) == length(b.bases) "tensor products of superoperators over composite bases are not implemented yet"
     LazySuperTensor(b,[embed(b,b,i,s) for (i,s) in enumerate(sops)])

--- a/src/QSymbolicsBase/basic_ops_homogeneous.jl
+++ b/src/QSymbolicsBase/basic_ops_homogeneous.jl
@@ -208,7 +208,8 @@ arguments(x::STensor) = x.terms
 operation(x::STensor) = ⊗
 head(x::STensor) = :⊗
 children(x::STensor) = [:⊗; x.terms]
-function ⊗(xs::Symbolic{T}...) where {T<:QObj}
+function ⊗(x::Symbolic{T}, xs::Symbolic{T}...) where {T<:QObj}
+    xs = (x, xs...)
     zero_ind = findfirst(x->iszero(x), xs)
     if isnothing(zero_ind)
         terms = flattenop(⊗, collect(xs))

--- a/test/general/qo_tests.jl
+++ b/test/general/qo_tests.jl
@@ -5,7 +5,8 @@ using QuantumSymbolics
     using QuantumOptics
     using QuantumSymbolics
     #using QuantumOpticsExt: LazyPrePost
-    LazyPrePost = Base.get_extension(QuantumSymbolics, :QuantumOpticsExt).LazyPrePost
+    qoext = Base.get_extension(QuantumSymbolics, :QuantumOpticsExt)
+    LazyPrePost = qoext.LazyPrePost
 
     bs = GenericBasis(2),GenericBasis(2)
     op0 = Operator(bs...,rand(2,2))
@@ -15,6 +16,8 @@ using QuantumSymbolics
     op32 = Operator(bs...,rand(2,2))
     l2 = LazyPrePost(op21,op22)
     l3 = LazyPrePost(op31,op32)
+    @test !applicable(tensor)
+    @test tensor(l2, l3) isa qoext.LazySuperTensor
     @test spre(op21)*spost(op22) ≈ spost(op22)*spre(op21)
     @test spre(op21)*spost(op22)*op0 ≈ l2*op0
     @test spre(op31)*spost(op32)*spre(op21)*spost(op22)*op0 ≈ (l3*l2)*op0 ≈ l3*(l2*op0)

--- a/test/general/zero_obj_tests.jl
+++ b/test/general/zero_obj_tests.jl
@@ -38,3 +38,15 @@ using QuantumSymbolics
         @test isequal(Ob*k, 0) && isequal(b*Ok, 0) && isequal(Ob*Ok, 0)
     end
 end
+
+@testset "Symbolic tensor arity" begin
+    A = SOperator(:A, SpinBasis(1//2))
+    B = SOperator(:B, SpinBasis(1//2))
+    C = SOperator(:C, SpinBasis(1//2))
+    O = SZeroOperator()
+
+    @test !applicable(⊗)
+    @test QuantumSymbolics.arguments((⊗)(A)) == [A]
+    @test QuantumSymbolics.arguments(A ⊗ B ⊗ C) == [A, B, C]
+    @test isequal(A ⊗ O ⊗ C, O)
+end


### PR DESCRIPTION
## Summary

- require a leading symbolic object for symbolic tensor construction while preserving unary and flattened N-ary results
- require a leading QuantumOptics superoperator before constructing `LazySuperTensor`
- make the shared tensor generic uniformly inapplicable with zero arguments
- prepare QuantumSymbolics v0.4.19

The QuantumOptics extension still strictly pirates `tensor(::AbstractSuperOperator, ...)`. Moving this implementation upstream is outside the scope of this compatibility repair.

## Tests

- `julia --project=. -e 'using Pkg; Pkg.test(; test_args=\`general/zero_obj_tests general/qo_tests general/aqua_tests\`)'`
