### PR TITLE
Add standard signatures to public docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # News
 
-## Unreleased
+## v0.4.20 - 2026-09-05
 
 - Add standard signatures to public API docstrings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+- Add standard signatures to public API docstrings.
+
 ## v0.4.19 - 2026-09-05
 
 - Require at least one argument for symbolic and QuantumOptics superoperator tensor products.

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.4.19"
 projects = ["benchmark", "docs"]
 
 [deps]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
@@ -30,6 +31,7 @@ QuantumOpticsExt = "QuantumOpticsBase"
 QuantumToolboxExt = "QuantumToolbox"
 
 [compat]
+DocStringExtensions = "0.9.5"
 Gabs = "1.3.5"
 Latexify = "0.16"
 LinearAlgebra = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumSymbolics"
 uuid = "efa7fd63-0460-4890-beb7-be1bbdfbaeae"
 authors = ["QuantumSymbolics.jl contributors"]
-version = "0.4.19"
+version = "0.4.20"
 
 [workspace]
 projects = ["benchmark", "docs"]

--- a/src/QSymbolicsBase/QSymbolicsBase.jl
+++ b/src/QSymbolicsBase/QSymbolicsBase.jl
@@ -1,6 +1,7 @@
 using Symbolics
 import Symbolics: simplify
 using SymbolicUtils
+using DocStringExtensions: TYPEDEF
 import SymbolicUtils: _isone
 using SymbolicUtils.Rewriters
 using TermInterface

--- a/src/QSymbolicsBase/linalg.jl
+++ b/src/QSymbolicsBase/linalg.jl
@@ -3,9 +3,17 @@
 ##
 
 #TODO upstream to QuantumInterface
-"""The commutator of two operators."""
+"""
+    commutator(o1, o2)
+
+The commutator of two operators.
+"""
 function commutator end
-"""The anticommutator of two operators."""
+"""
+    anticommutator(o1, o2)
+
+The anticommutator of two operators.
+"""
 function anticommutator end
 
 """Symbolic commutator of two operators.
@@ -118,7 +126,10 @@ function Base.show(io::IO, x::SConjugate)
 end
 
 
-"""Projector for a given ket.
+"""
+$TYPEDEF
+
+Projector for a given ket.
 
 ```jldoctest
 julia> projector(X1⊗X2)

--- a/src/QSymbolicsBase/literal_objects.jl
+++ b/src/QSymbolicsBase/literal_objects.jl
@@ -85,7 +85,11 @@ end
 ishermitian(x::SOperator) = false
 isunitary(x::SOperator) = false
 
-"""Symbolic Hermitian operator"""
+"""
+$TYPEDEF
+
+Symbolic Hermitian operator
+"""
 struct SHermitianOperator <: Symbolic{AbstractOperator}
     name::Symbol
     basis::Basis
@@ -95,7 +99,11 @@ SHermitianOperator(name) = SHermitianOperator(name, qubit_basis)
 ishermitian(::SHermitianOperator) = true
 isunitary(::SHermitianOperator) = false
 
-"""Symbolic unitary operator"""
+"""
+$TYPEDEF
+
+Symbolic unitary operator
+"""
 struct SUnitaryOperator <: Symbolic{AbstractOperator}
     name::Symbol
     basis::Basis

--- a/src/QSymbolicsBase/predefined.jl
+++ b/src/QSymbolicsBase/predefined.jl
@@ -38,17 +38,41 @@ end
 symbollabel(x::PositionEigenState) = "δₓ($(x.x))"
 
 const qubit_basis = SpinBasis(1//2)
-"""Basis state of σˣ"""
+"""
+    X1
+
+Basis state of σˣ
+"""
 const X1 = const X₁ = const Lp = const L₊ = XBasisState(1, qubit_basis)
-"""Basis state of σˣ"""
+"""
+    X2
+
+Basis state of σˣ
+"""
 const X2 = const X₂ = const Lm = const L₋ = XBasisState(2, qubit_basis)
-"""Basis state of σʸ"""
+"""
+    Y1
+
+Basis state of σʸ
+"""
 const Y1 = const Y₁ = const Lpi = const L₊ᵢ = YBasisState(1, qubit_basis)
-"""Basis state of σʸ"""
+"""
+    Y2
+
+Basis state of σʸ
+"""
 const Y2 = const Y₂ = const Lmi = const L₋ᵢ = YBasisState(2, qubit_basis)
-"""Basis state of σᶻ"""
+"""
+    Z1
+
+Basis state of σᶻ
+"""
 const Z1 = const Z₁ = const L0 = const L₀ = ZBasisState(1, qubit_basis)
-"""Basis state of σᶻ"""
+"""
+    Z2
+
+Basis state of σᶻ
+"""
 const Z2 = const Z₂ = const L1 = const L₁ = ZBasisState(2, qubit_basis)
 
 ##
@@ -134,28 +158,63 @@ for control in (:X, :Y, :Z)
     end
 end
 
-"""Pauli X operator, also available as the constant `σˣ`"""
+"""
+    X
+
+Pauli X operator, also available as the constant `σˣ`
+"""
 const X = const σˣ = XGate()
-"""Pauli Y operator, also available as the constant `σʸ`"""
+"""
+    Y
+
+Pauli Y operator, also available as the constant `σʸ`
+"""
 const Y = const σʸ = YGate()
-"""Pauli Z operator, also available as the constant `σᶻ`"""
+"""
+    Z
+
+Pauli Z operator, also available as the constant `σᶻ`
+"""
 const Z = const σᶻ = ZGate()
-"""Pauli "minus" operator, also available as the constant `σ₋`"""
+"""
+    Pm
+
+Pauli "minus" operator, also available as the constant `σ₋`
+"""
 const Pm = const σ₋ = PauliM()
-"""Pauli "plus" operator, also available as the constant `σ₊`"""
+"""
+    Pp
+
+Pauli "plus" operator, also available as the constant `σ₊`
+"""
 const Pp = const σ₊ = PauliP()
-"""Hadamard gate"""
+"""
+    H
+
+Hadamard gate
+"""
 const H = HGate()
-"""CNOT gate"""
+"""
+    CNOT
+
+CNOT gate
+"""
 const CNOT = CNOTGate()
-"""CPHASE gate"""
+"""
+    CPHASE
+
+CPHASE gate
+"""
 const CPHASE = CPHASEGate()
 
 ##
 # Other special or useful objects
 ##
 
-"""Completely depolarized state
+"""
+$TYPEDEF
+
+Completely depolarized state
 
 ```jldoctest
 julia> MixedState(X1⊗X2)

--- a/src/QSymbolicsBase/predefined_CPTP.jl
+++ b/src/QSymbolicsBase/predefined_CPTP.jl
@@ -30,7 +30,10 @@ end
 basis(x::AmplifierCPTP) = inf_fock_basis
 symbollabel(x::AmplifierCPTP) = "𝒜𝓂𝓅"
 
-"""Single-qubit Pauli noise CPTP map
+"""
+$TYPEDEF
+
+Single-qubit Pauli noise CPTP map
 
 ```jldoctest
 julia> apply!(express(Z1), [1], express(PauliNoiseCPTP(1/4,1/4,1/4)))

--- a/src/QSymbolicsBase/predefined_fock.jl
+++ b/src/QSymbolicsBase/predefined_fock.jl
@@ -9,13 +9,21 @@ abstract type AbstractTwoBosonState <: SpecialKet end
 basis(::AbstractSingleBosonState) = inf_fock_basis
 basis(::AbstractTwoBosonState) = inf_fock_basis^2
 
-"""Fock state in defined Fock basis."""
+"""
+$TYPEDEF
+
+Fock state in defined Fock basis.
+"""
 @withmetadata struct FockState <: AbstractSingleBosonState
     idx::Int
 end
 symbollabel(x::FockState) = "$(x.idx)"
 
-"""Coherent state in defined Fock basis."""
+"""
+$TYPEDEF
+
+Coherent state in defined Fock basis.
+"""
 @withmetadata struct CoherentState <: AbstractSingleBosonState
     alpha::Number # TODO parameterize
 end
@@ -33,7 +41,11 @@ symbollabel(x::SqueezedState) = "0,$(x.z)"
 end
 symbollabel(x::TwoSqueezedState) = "0,$(x.z)"
 
-"""Single-mode vacuum state"""
+"""
+    vac
+
+Single-mode vacuum state
+"""
 const vac = const F₀ = const F0 = FockState(0)
 """Single photon state"""
 const F₁ = const F1 = FockState(1)
@@ -51,7 +63,10 @@ basis(x::AbstractSingleBosonOp) = inf_fock_basis
 isexpr(::AbstractTwoBosonGate) = false
 basis(x::AbstractTwoBosonOp) = inf_fock_basis^2
 
-"""Number operator.
+"""
+$TYPEDEF
+
+Number operator.
 
 ```jldoctest
 julia> f = FockState(2)
@@ -67,7 +82,10 @@ julia> qsimplify(num*f, rewriter=qsimplify_fock)
 @withmetadata struct NumberOp <: AbstractSingleBosonOp end
 symbollabel(::NumberOp) = "n"
 
-"""Creation (raising) operator.
+"""
+$TYPEDEF
+
+Creation (raising) operator.
 
 ```jldoctest
 julia> f = FockState(2)
@@ -83,7 +101,10 @@ julia> qsimplify(create*f, rewriter=qsimplify_fock)
 @withmetadata struct CreateOp <: AbstractSingleBosonOp end
 symbollabel(::CreateOp) = "a†"
 
-"""Annihilation (lowering or destroy) operator in defined Fock basis.
+"""
+$TYPEDEF
+
+Annihilation (lowering or destroy) operator in defined Fock basis.
 
 ```jldoctest
 julia> f = FockState(2)
@@ -99,7 +120,10 @@ julia> qsimplify(destroy*f, rewriter=qsimplify_fock)
 @withmetadata struct DestroyOp <: AbstractSingleBosonOp end
 symbollabel(::DestroyOp) = "a"
 
-"""Phase-shift operator in defined Fock basis.
+"""
+$TYPEDEF
+
+Phase-shift operator in defined Fock basis.
 
 ```jldoctest
 julia> c = CoherentState(im)
@@ -117,7 +141,10 @@ julia> qsimplify(phase*c, rewriter=qsimplify_fock)
 end
 symbollabel(x::PhaseShiftOp) = "U($(x.phase))"
 
-"""Displacement operator in defined Fock basis.
+"""
+$TYPEDEF
+
+Displacement operator in defined Fock basis.
 
 ```jldoctest
 julia> f = FockState(0)
@@ -135,15 +162,29 @@ julia> qsimplify(displace*f, rewriter=qsimplify_fock)
 end
 symbollabel(x::DisplaceOp) = "D($(x.alpha))"
 
-"""Number operator, also available as the constant `n̂`, in an infinite dimension Fock basis."""
+"""
+    N
+
+Number operator, also available as the constant `n̂`, in an infinite dimension Fock basis.
+"""
 const N = const n̂ = NumberOp()
-"""Creation operator, also available as the constant `âꜛ`, in an infinite dimension Fock basis.
+"""
+    Create
+
+Creation operator, also available as the constant `âꜛ`, in an infinite dimension Fock basis.
 There is no unicode dagger superscript, so we use the uparrow"""
 const Create = const âꜛ = CreateOp()
-"""Annihilation operator, also available as the constant `â`, in an infinite dimension Fock basis."""
+"""
+    Destroy
+
+Annihilation operator, also available as the constant `â`, in an infinite dimension Fock basis.
+"""
 const Destroy = const â = DestroyOp()
 
-"""Squeezing operator in defined Fock basis.
+"""
+$TYPEDEF
+
+Squeezing operator in defined Fock basis.
 
 ```jldoctest
 julia> S = SqueezeOp(pi)

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -2,7 +2,10 @@
 
 export StabilizerState
 
-"""State defined by a stabilizer tableau
+"""
+$TYPEDEF
+
+State defined by a stabilizer tableau
 
 For full functionality you also need to import the `QuantumClifford` library.
 


### PR DESCRIPTION
## Summary

- Add leading signatures to all 34 QuantumSymbolics-owned docstrings reported by the audit.
- Use DocStringExtensions TYPEDEF for concrete types and explicit signatures for constants and empty generic functions.
- Keep the documentation builder unchanged, so this PR is independent of #224.

## Validation

- Focused doctest suite passed.
- Full general suite passed: 487 passed, 2 expected broken.
- Documentation built with a temporary DocumenterCodeBlocks 1.5.0 plugin configuration and emitted no CodeBlocks warnings; the temporary integration was removed before commit.
- Independent review found no issues.