### PR TITLE
Clarify bounty contributor code generation and office-hours rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ by NSF Grant 2346089 "Research Infrastructure: CIRC: New: Full-stack Codesign To
 ## Bounties
 
 [We run many bug bounties and encourage submissions from novices (we are happy to help onboard you in the field).](https://github.com/QuantumSavory/.github/blob/main/BUG_BOUNTIES.md)
+
+New contributors participating in the bounty program must not use LLMs or coding agents to generate code. They may use these tools to analyze existing code and to review code they have written themselves. They must attend [office hours](https://quantumsavory.org/community/office-hours/) to discuss their pull request.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -220,3 +220,5 @@ by NSF Grant 2346089 "Research Infrastructure: CIRC: New: Full-stack Codesign To
 ## Bounties
 
 [We run many bug bounties and encourage submissions from novices (we are happy to help onboard you in the field).](https://github.com/QuantumSavory/.github/blob/main/BUG_BOUNTIES.md)
+
+New contributors participating in the bounty program must not use LLMs or coding agents to generate code. They may use these tools to analyze existing code and to review code they have written themselves. They must attend [office hours](https://quantumsavory.org/community/office-hours/) to discuss their pull request.


### PR DESCRIPTION
Clarify the rules for new contributors participating in the bounty program in the README bounty section and documentation front page: they must not use LLMs or coding agents to generate code, may use those tools to analyze existing code and review code they wrote themselves, and must attend office hours to discuss their PR.

Keep the existing bounty link and direct contributors to the maintained office-hours page. This is part of the cross-repository wording update in QuantumSavory/.github#2 and QuantumSavory/quantumsavory.org#3.

Validation: reviewed all tracked bounty mentions, checked policy consistency, and ran `git diff --check`; independent review passed. Julia tests and full Documenter builds were not run because these are prose-only edits.
