### PR TITLE
Use QuantumSavory Julia setup plugin in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ secrets:
 steps:
   - label: "General Tests"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#dbd20b9d63930875b96dc7a048e57ffb437a0e4c: # v1.14
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -18,7 +18,7 @@ steps:
 
   - label: "General Tests (alpha)"
     plugins:
-      - Krastanov-agent/julia#bb0dd898e0190fa025fa9eddbf5b39665edc8e6c:
+      - QuantumSavory/julia#dbd20b9d63930875b96dc7a048e57ffb437a0e4c: # v1.14
           version: "alpha"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -27,7 +27,7 @@ steps:
 
   - label: "JET Tests"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#dbd20b9d63930875b96dc7a048e57ffb437a0e4c: # v1.14
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -37,7 +37,7 @@ steps:
   - label: "Docs"
     branches: "!dependabot/*"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#dbd20b9d63930875b96dc7a048e57ffb437a0e4c: # v1.14
           version: "1"
       - QuantumSavory/julia-xvfb#v1:
     secrets:
@@ -49,7 +49,7 @@ steps:
   
   - label: "Downstream Tests - {{matrix.PACKAGE}}"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#dbd20b9d63930875b96dc7a048e57ffb437a0e4c: # v1.14
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
     command:
@@ -67,7 +67,7 @@ steps:
 
   - label: "Downstream Dev Tests - {{matrix.PACKAGE}}"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#dbd20b9d63930875b96dc7a048e57ffb437a0e4c: # v1.14
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
     command:


### PR DESCRIPTION
## Summary

Use the QuantumSavory Julia setup plugin for all six Buildkite steps, including the alpha job. Pin the reviewed v1.14 commit (`dbd20b9d63930875b96dc7a048e57ffb437a0e4c`). Leave Julia selectors, commands, cache settings, and the test/coverage plugins unchanged.

The fork includes the Bash 3.2 option-check fix needed by the macOS agents. Public main [Buildkite build #587](https://buildkite.com/quantumsavory/quantumsymbolics-dot-jl/builds/587) failed in four setup hooks before package tests started. It also includes the named prerelease selector already required by the alpha step.

## Validation

- Parsed the pipeline YAML and checked that its data differs only in the six setup plugin references.
- Reviewed the fork's changes and verified that v1.14 resolves to the pinned commit.
- Both plugin hooks pass `bash -O extglob -n` locally.
- The fork's version-selection helpers resolve `1` to `1.13` and `alpha` to `1.13.0` against the current release index.
- `git diff --check` passes.

The package code is unchanged. Full local general suites already passed on the base commit with Julia 1.10.12, 1.11.9, 1.12.7, and 1.13.0; JET and released/development QuantumSavory downstream suites also passed. Those suites were not repeated for this reference-only change. macOS Buildkite execution still requires hosted validation.

CI-only change; please apply `Skip-Changelog`. This PR is from a fork because the contributor account has read-only upstream access; Buildkite requires an upstream branch or maintainer action.
