### PR TITLE
ci: follow QuantumSavory Buildkite v1 tags

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ secrets:
 steps:
   - label: "General Tests"
     plugins:
-      - QuantumSavory/julia#v1.14:
+      - QuantumSavory/julia#v1:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -18,7 +18,7 @@ steps:
 
   - label: "General Tests (alpha)"
     plugins:
-      - QuantumSavory/julia#v1.14:
+      - QuantumSavory/julia#v1:
           version: "alpha"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -27,7 +27,7 @@ steps:
 
   - label: "JET Tests"
     plugins:
-      - QuantumSavory/julia#v1.14:
+      - QuantumSavory/julia#v1:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -37,9 +37,9 @@ steps:
   - label: "Docs"
     branches: "!dependabot/*"
     plugins:
-      - QuantumSavory/julia#v1.14:
+      - QuantumSavory/julia#v1:
           version: "1"
-      - QuantumSavory/julia-xvfb#v1.2:
+      - QuantumSavory/julia-xvfb#v1:
     secrets:
       DOCUMENTER_KEY: DOCUMENTER_KEY_QuantumSymbolics
       ANYTHINGLLM_API_KEY: ANYTHINGLLM_API_KEY
@@ -49,7 +49,7 @@ steps:
   
   - label: "Downstream Tests - {{matrix.PACKAGE}}"
     plugins:
-      - QuantumSavory/julia#v1.14:
+      - QuantumSavory/julia#v1:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
     command:
@@ -67,7 +67,7 @@ steps:
 
   - label: "Downstream Dev Tests - {{matrix.PACKAGE}}"
     plugins:
-      - QuantumSavory/julia#v1.14:
+      - QuantumSavory/julia#v1:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
     command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ secrets:
 steps:
   - label: "General Tests"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -18,7 +18,7 @@ steps:
 
   - label: "General Tests (alpha)"
     plugins:
-      - Krastanov-agent/julia#bb0dd898e0190fa025fa9eddbf5b39665edc8e6c:
+      - QuantumSavory/julia#v1.14:
           version: "alpha"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -27,7 +27,7 @@ steps:
 
   - label: "JET Tests"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -37,9 +37,9 @@ steps:
   - label: "Docs"
     branches: "!dependabot/*"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
-      - QuantumSavory/julia-xvfb#v1:
+      - QuantumSavory/julia-xvfb#v1.2:
     secrets:
       DOCUMENTER_KEY: DOCUMENTER_KEY_QuantumSymbolics
       ANYTHINGLLM_API_KEY: ANYTHINGLLM_API_KEY
@@ -49,7 +49,7 @@ steps:
   
   - label: "Downstream Tests - {{matrix.PACKAGE}}"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
     command:
@@ -67,7 +67,7 @@ steps:
 
   - label: "Downstream Dev Tests - {{matrix.PACKAGE}}"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
     command:


### PR DESCRIPTION
Use `QuantumSavory/julia#v1` for every external Julia setup step in Buildkite. Use `QuantumSavory/julia-xvfb#v1` for the existing Xvfb steps. The pipelines follow the QuantumSavory forks’ maintained major-version tags as new 1.x fixes are published.

Julia runtime selectors, plugin options, commands, and job definitions are unchanged.

Validation: parsed all Buildkite YAML files, verified semantic equality after normalizing only the plugin reference keys, reviewed the exact tag substitutions, and ran `git diff --check`. Verified that both QuantumSavory `v1` tags currently point to the latest tagged fixes. Julia/package/application suites and full hosted Buildkite execution were not run locally because only plugin references changed.
